### PR TITLE
Fix: Display the right day when showFirstDayOfWeekFirst is true

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -118,16 +118,16 @@ public final class WeekView<T> extends View
 
         viewState.update(config, this);
 
-        if (viewState.isFirstDraw) {
-            viewState.isFirstDraw = false;
-            config.drawingConfig.moveCurrentOriginIfFirstDraw(config);
-        }
-
         config.drawingConfig.refreshAfterZooming(config);
         config.drawingConfig.updateVerticalOrigin(config);
 
         notifyScrollListeners();
         prepareEventDrawing(canvas);
+
+        if (viewState.isFirstDraw) {
+            viewState.isFirstDraw = false;
+            config.drawingConfig.moveCurrentOriginIfFirstDraw(config);
+        }
 
         final DrawingContext drawingContext = DrawingContext.create(config);
         eventChipsProvider.loadEventsIfNecessary(this, drawingContext.dayRange);
@@ -177,6 +177,10 @@ public final class WeekView<T> extends View
     }
 
     private void calculateWidthPerDay() {
+        // Initialize drawConfig.timeColumnWidth at first call
+        if (drawConfig.timeColumnWidth == 0) {
+            drawConfig.timeColumnWidth = drawConfig.timeTextWidth + config.timeColumnPadding * 2;
+        }
         // Calculate the available width for each day
         drawConfig.widthPerDay = getWidth()
                 - drawConfig.timeColumnWidth


### PR DESCRIPTION
In the Basic  example, the first day displayed should be the Monday of the week.
It was not the case because variables were not correctly initialized when computing the `WeekViewDrawingConfig.currentOrigin.x` position.