### PR TITLE
Correct the display of all day events in the header

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/EventChipRectCalculator.java
+++ b/library/src/main/java/com/alamkanak/weekview/EventChipRectCalculator.java
@@ -54,11 +54,11 @@ class EventChipRectCalculator {
     }
 
     RectF calculateAllDayEvent(EventChip eventChip, float startFromPixel) {
-        final float headerHeight = config.headerRowPadding * 2 + config.drawingConfig.headerMarginBottom;
+        final float headerHeight = config.headerRowPadding + config.headerRowPadding / 2
+            + config.drawingConfig.headerMarginBottom;
         final float widthPerDay = config.drawingConfig.widthPerDay;
-        float halfTextHeight = config.drawingConfig.headerTextHeight / 2;
         // Calculate top
-        final float top = headerHeight + halfTextHeight + config.eventMarginVertical;
+        final float top = headerHeight + config.drawingConfig.headerTextHeight + config.eventMarginVertical;
 
         // Calculate bottom
         final float bottom = top + eventChip.bottom;

--- a/library/src/main/java/com/alamkanak/weekview/EventChipRectCalculator.java
+++ b/library/src/main/java/com/alamkanak/weekview/EventChipRectCalculator.java
@@ -32,16 +32,17 @@ class EventChipRectCalculator {
         final float verticalDistanceFromBottom = config.hourHeight * HOURS_PER_DAY * eventChip.bottom / MINUTES_PER_DAY;
         final float bottom = verticalDistanceFromBottom + verticalOrigin + totalHeaderHeight - eventMargin;
 
-        // Calculate left
+        // Calculate left and right
         float left = startFromPixel + eventChip.left * widthPerDay;
-        if (left < startFromPixel) {
-            left += config.overlappingEventGap;
+        float right = left + eventChip.width * widthPerDay;
+
+        // Adjust left and right with overlappingEventGap
+        if (left > startFromPixel) {
+            left += config.overlappingEventGap / 2;
         }
 
-        // Calculate right
-        float right = left + eventChip.width * widthPerDay;
         if (right < startFromPixel + widthPerDay) {
-            right -= config.overlappingEventGap;
+            right -= config.overlappingEventGap / 2;
         }
 
         boolean hasNoOverlaps = (right == startFromPixel + widthPerDay);
@@ -55,24 +56,24 @@ class EventChipRectCalculator {
     RectF calculateAllDayEvent(EventChip eventChip, float startFromPixel) {
         final float headerHeight = config.headerRowPadding * 2 + config.drawingConfig.headerMarginBottom;
         final float widthPerDay = config.drawingConfig.widthPerDay;
-        final float halfTextHeight = config.drawingConfig.timeTextHeight / 2;
-
+        float halfTextHeight = config.drawingConfig.headerTextHeight / 2;
         // Calculate top
         final float top = headerHeight + halfTextHeight + config.eventMarginVertical;
 
         // Calculate bottom
         final float bottom = top + eventChip.bottom;
 
-        // Calculate left
+        // Calculate left & right
         float left = startFromPixel + eventChip.left * widthPerDay;
-        if (left < startFromPixel) {
-            left += config.overlappingEventGap;
+        float right = left + eventChip.width * widthPerDay;
+
+        // Adjust left and right with overlappingEventGap
+        if (left > startFromPixel) {
+            left += config.overlappingEventGap / 2;
         }
 
-        // Calculate right
-        float right = left + eventChip.width * widthPerDay;
         if (right < startFromPixel + widthPerDay) {
-            right -= config.overlappingEventGap;
+            right -= config.overlappingEventGap / 2;
         }
 
         boolean hasNoOverlaps = (right == startFromPixel + widthPerDay);

--- a/library/src/main/java/com/alamkanak/weekview/EventsDrawer.java
+++ b/library/src/main/java/com/alamkanak/weekview/EventsDrawer.java
@@ -182,7 +182,6 @@ class EventsDrawer<T> {
             stringBuilder.append(event.getLocation());
         }
 
-        final int availableHeight = (int) (bottom - top - config.eventPadding * 2);
         final int availableWidth = (int) (right - left - config.eventPadding * 2);
 
         // Get text dimensions.
@@ -191,6 +190,12 @@ class EventsDrawer<T> {
                 stringBuilder, textPaint, availableWidth, ALIGN_NORMAL, 1.0f, 0.0f, false);
 
         final int lineHeight = textLayout.getHeight() / textLayout.getLineCount();
+
+        // For an all day event, we display just one line
+        final int chipHeight = lineHeight + (config.eventPadding * 2);
+        eventChip.rect.bottom = eventChip.rect.top + chipHeight;
+        // Compute the available height on the right size of the chip
+        final int availableHeight = (int) (eventChip.rect.bottom - top - config.eventPadding * 2);
 
         if (availableHeight >= lineHeight) {
             int availableLineCount = availableHeight / lineHeight;
@@ -209,8 +214,6 @@ class EventsDrawer<T> {
             } while (textLayout.getHeight() > availableHeight);
         }
 
-        final int chipHeight = lineHeight + (config.eventPadding * 2);
-        eventChip.rect.bottom = eventChip.rect.top + chipHeight;
         return textLayout;
     }
 

--- a/library/src/main/java/com/alamkanak/weekview/HeaderRowDrawer.java
+++ b/library/src/main/java/com/alamkanak/weekview/HeaderRowDrawer.java
@@ -66,11 +66,9 @@ class HeaderRowDrawer<T> {
         if (containsAllDayEvent) {
             final float headerTextSize = drawConfig.eventTextPaint.getTextSize();
             final float totalEventPadding = config.eventPadding * 2;
-            final float eventChipBottomPadding = config.timeColumnTextSize / 4;
 
             return drawConfig.headerTextHeight + (headerTextSize
-                    + totalEventPadding + eventChipBottomPadding
-                    + headerRowBottomLine + drawConfig.headerMarginBottom);
+                    + totalEventPadding + headerRowBottomLine + drawConfig.headerMarginBottom);
         } else {
             return drawConfig.headerTextHeight + headerRowBottomLine;
         }


### PR DESCRIPTION
Changing the eventTextColor to red for example, we could see that the text in header event chip was not well displayed. This PR correct this.

Fixes :

- Multiple events in same day have now the same width (modifications in EventChipRectCalculator)
- The available height is now well computed for text in header event chips
- The position of the event chip is at headerRowPadding / 2 of the text and headerRowPadding / 2 of the bottom header line