### PR TITLE
Fix #25 : goToDate() don't scroll to specific date

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/DateUtils.kt
+++ b/library/src/main/java/com/alamkanak/weekview/DateUtils.kt
@@ -48,7 +48,7 @@ internal object DateUtils {
 
     @JvmStatic
     fun getDaysUntilDate(date: Calendar): Int {
-        val dateInMillis = date.timeInMillis
+        val dateInMillis = date.withTimeAtStartOfDay().timeInMillis
         val todayInMillis = today().timeInMillis
         val diff = dateInMillis - todayInMillis
         return (diff / Constants.DAY_IN_MILLIS).toInt()

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -19,6 +19,7 @@ import static com.alamkanak.weekview.DateUtils.today;
 import static java.lang.Math.ceil;
 import static java.lang.Math.min;
 import static java.util.Calendar.DATE;
+import static java.util.Calendar.DAY_OF_WEEK;
 import static java.util.Calendar.HOUR_OF_DAY;
 
 /**
@@ -117,6 +118,8 @@ public final class WeekView<T> extends View
         super.onDraw(canvas);
         final boolean isFirstDraw = viewState.isFirstDraw();
 
+        calculateWidthPerDay();
+
         viewState.update(config, this);
 
         config.drawingConfig.refreshAfterZooming(config);
@@ -174,7 +177,6 @@ public final class WeekView<T> extends View
         data.clearEventChipsCache();
         canvas.save();
         clipEventsRect(canvas);
-        calculateWidthPerDay();
     }
 
     private void calculateWidthPerDay() {
@@ -1009,7 +1011,12 @@ public final class WeekView<T> extends View
 
         viewState.setShouldRefreshEvents(true);
 
-        final int diff = DateUtils.getDaysUntilDate(date);
+        int diff = DateUtils.getDaysUntilDate(date);
+
+        if (config.numberOfVisibleDays >= 7 && config.showFirstDayOfWeekFirst) {
+                diff -= (date.get(DAY_OF_WEEK) + 7 - config.firstDayOfWeek) % 7;
+        }
+
         config.drawingConfig.currentOrigin.x = diff * (-1) * config.getTotalDayWidth();
         invalidate();
     }

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -161,10 +161,12 @@ public final class WeekView<T> extends View
         final Calendar today = today();
 
         viewState.setFirstVisibleDay((Calendar) today.clone());
+        viewState.setLastVisibleDay((Calendar) today.clone());
 
         final float totalDayWidth = config.getTotalDayWidth();
         final int delta = (int) ceil(drawConfig.currentOrigin.x / totalDayWidth) * -1;
         viewState.getFirstVisibleDay().add(DATE, delta);
+        viewState.getLastVisibleDay().add(DATE, config.numberOfVisibleDays - 1 + delta);
 
         final boolean hasFirstVisibleDayChanged = !viewState.getFirstVisibleDay().equals(oldFirstVisibleDay);
         if (hasFirstVisibleDayChanged && getScrollListener() != null) {
@@ -1014,7 +1016,7 @@ public final class WeekView<T> extends View
         int diff = DateUtils.getDaysUntilDate(date);
 
         if (config.numberOfVisibleDays >= 7 && config.showFirstDayOfWeekFirst) {
-                diff -= (date.get(DAY_OF_WEEK) + 7 - config.firstDayOfWeek) % 7;
+                diff -= config.drawingConfig.computeDifferenceWithFirstDayOfWeek(config, date);
         }
 
         config.drawingConfig.currentOrigin.x = diff * (-1) * config.getTotalDayWidth();

--- a/library/src/main/java/com/alamkanak/weekview/WeekViewDrawingConfig.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekViewDrawingConfig.java
@@ -155,10 +155,14 @@ class WeekViewDrawingConfig {
         final boolean currentDayIsNotToday = today.get(DAY_OF_WEEK) != config.firstDayOfWeek;
 
         if (isWeekView && currentDayIsNotToday && config.showFirstDayOfWeekFirst) {
-            int difference = (today.get(DAY_OF_WEEK) + 7 - config.firstDayOfWeek) % 7;
+            int difference = computeDifferenceWithFirstDayOfWeek(config, today);
 
             currentOrigin.x += (widthPerDay + config.columnGap) * difference;
         }
+    }
+
+    int computeDifferenceWithFirstDayOfWeek(@NonNull WeekViewConfig config ,@NonNull Calendar date) {
+        return (date.get(DAY_OF_WEEK) + 7 - config.firstDayOfWeek) % 7;
     }
 
     void refreshAfterZooming(WeekViewConfig config) {

--- a/library/src/main/java/com/alamkanak/weekview/WeekViewDrawingConfig.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekViewDrawingConfig.java
@@ -155,15 +155,7 @@ class WeekViewDrawingConfig {
         final boolean currentDayIsNotToday = today.get(DAY_OF_WEEK) != config.firstDayOfWeek;
 
         if (isWeekView && currentDayIsNotToday && config.showFirstDayOfWeekFirst) {
-            int currentDay = today.get(DAY_OF_WEEK);
-            int difference;
-
-            if (config.firstDayOfWeek == MONDAY && currentDay == SUNDAY) {
-                // Special case, because Sunday (1) has a lower index than Monday (2)
-                difference = 6;
-            } else {
-                difference = today.get(DAY_OF_WEEK) - config.firstDayOfWeek;
-            }
+            int difference = (today.get(DAY_OF_WEEK) + 7 - config.firstDayOfWeek) % 7;
 
             currentOrigin.x += (widthPerDay + config.columnGap) * difference;
         }

--- a/library/src/main/java/com/alamkanak/weekview/WeekViewViewState.kt
+++ b/library/src/main/java/com/alamkanak/weekview/WeekViewViewState.kt
@@ -36,6 +36,7 @@ internal class WeekViewViewState {
 
         areDimensionsInvalid = false
         scrollToDay?.let {
+            isFirstDraw = false
             listener.goToDate(it)
         }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -11,6 +11,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {

--- a/sample/src/main/java/com/alamkanak/weekview/sample/StaticActivity.java
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/StaticActivity.java
@@ -4,9 +4,14 @@ import android.graphics.RectF;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.ImageView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.alamkanak.weekview.DateTimeInterpreter;
+import com.alamkanak.weekview.DateUtils;
 import com.alamkanak.weekview.EmptyViewLongPressListener;
 import com.alamkanak.weekview.EventClickListener;
 import com.alamkanak.weekview.EventLongPressListener;
@@ -29,12 +34,17 @@ public class StaticActivity extends AppCompatActivity
     private WeekView<Event> mWeekView;
     private EventsDatabase mDatabase;
 
+    private TextView mDateTV;
+    private Calendar currentCal;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_static);
 
         mDatabase = new FakeEventsDatabase(this);
+
+        mDateTV = findViewById(R.id.dates);
 
         mWeekView = findViewById(R.id.weekView);
         mWeekView.setOnEventClickListener(this);
@@ -43,6 +53,29 @@ public class StaticActivity extends AppCompatActivity
         mWeekView.setEmptyViewLongPressListener(this);
 
         setupDateTimeInterpreter();
+
+        currentCal = DateUtils.today();
+        updateDateText();
+
+        ImageView left = findViewById(R.id.left_arrow);
+        left.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                currentCal.add(Calendar.DAY_OF_MONTH, -7);
+                updateDateText();
+                mWeekView.goToDate(currentCal);
+            }
+        });
+
+        ImageView right = findViewById(R.id.right_arrow);
+        right.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                currentCal.add(Calendar.DAY_OF_MONTH, 7);
+                updateDateText();
+                mWeekView.goToDate(currentCal);
+            }
+        });
     }
 
     /**
@@ -99,4 +132,8 @@ public class StaticActivity extends AppCompatActivity
         Toast.makeText(this, "Empty view long pressed: " + getEventTitle(time), Toast.LENGTH_SHORT).show();
     }
 
+    private void updateDateText() {
+        SimpleDateFormat format = new SimpleDateFormat("dd/MM/yyyy", Locale.getDefault());
+        mDateTV.setText(format.format(currentCal.getTime()));
+    }
 }

--- a/sample/src/main/java/com/alamkanak/weekview/sample/StaticActivity.java
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/StaticActivity.java
@@ -2,6 +2,7 @@ package com.alamkanak.weekview.sample;
 
 import android.graphics.RectF;
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -35,7 +36,6 @@ public class StaticActivity extends AppCompatActivity
     private EventsDatabase mDatabase;
 
     private TextView mDateTV;
-    private Calendar currentCal;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -54,16 +54,14 @@ public class StaticActivity extends AppCompatActivity
 
         setupDateTimeInterpreter();
 
-        currentCal = DateUtils.today();
-        updateDateText();
-
         ImageView left = findViewById(R.id.left_arrow);
         left.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                currentCal.add(Calendar.DAY_OF_MONTH, -7);
-                updateDateText();
-                mWeekView.goToDate(currentCal);
+                Calendar cal = mWeekView.getFirstVisibleDay();
+                cal.add(Calendar.DAY_OF_MONTH, -7);
+                mWeekView.goToDate(cal);
+                refreshText();
             }
         });
 
@@ -71,11 +69,14 @@ public class StaticActivity extends AppCompatActivity
         right.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                currentCal.add(Calendar.DAY_OF_MONTH, 7);
-                updateDateText();
-                mWeekView.goToDate(currentCal);
+                Calendar cal = mWeekView.getFirstVisibleDay();
+                cal.add(Calendar.DAY_OF_MONTH, 7);
+                mWeekView.goToDate(cal);
+                refreshText();
             }
         });
+
+        refreshText();
     }
 
     /**
@@ -132,8 +133,19 @@ public class StaticActivity extends AppCompatActivity
         Toast.makeText(this, "Empty view long pressed: " + getEventTitle(time), Toast.LENGTH_SHORT).show();
     }
 
+    private void refreshText() {
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                updateDateText();
+            }
+        }, 100);
+    }
+
     private void updateDateText() {
         SimpleDateFormat format = new SimpleDateFormat("dd/MM/yyyy", Locale.getDefault());
-        mDateTV.setText(format.format(currentCal.getTime()));
+        mDateTV.setText(getString(R.string.date_infos
+            , format.format(mWeekView.getFirstVisibleDay().getTime())
+            , format.format(mWeekView.getLastVisibleDay().getTime())));
     }
 }

--- a/sample/src/main/res/drawable/ic_chevron_left_black_24dp.xml
+++ b/sample/src/main/res/drawable/ic_chevron_left_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15.41,7.41L14,6l-6,6 6,6 1.41,-1.41L10.83,12z"/>
+</vector>

--- a/sample/src/main/res/drawable/ic_chevron_right_black_24dp.xml
+++ b/sample/src/main/res/drawable/ic_chevron_right_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z"/>
+</vector>

--- a/sample/src/main/res/layout/activity_static.xml
+++ b/sample/src/main/res/layout/activity_static.xml
@@ -1,9 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:orientation="vertical">
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="horizontal">
+
+        <ImageView
+          android:id="@+id/left_arrow"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_weight="1"
+          android:layout_marginTop="8dp"
+          android:layout_marginBottom="8dp"
+          app:srcCompat="@drawable/ic_chevron_left_black_24dp"/>
+
+        <TextView
+          android:id="@+id/dates"
+          android:layout_width="0dp"
+          android:layout_height="match_parent"
+          android:layout_weight="5"
+          android:gravity="center"
+          android:layout_marginTop="8dp"
+          android:layout_marginBottom="8dp"
+          android:layout_marginStart="8dp"
+          android:layout_marginEnd="8dp"
+          tools:text="01/01/2018"/>
+
+        <ImageView
+          android:id="@+id/right_arrow"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_weight="1"
+          android:layout_marginTop="8dp"
+          android:layout_marginBottom="8dp"
+          app:srcCompat="@drawable/ic_chevron_right_black_24dp"/>
+
+    </LinearLayout>
 
     <com.alamkanak.weekview.WeekView
         android:id="@+id/weekView"
@@ -21,7 +59,7 @@
         app:nowLineDotColor="@color/accent"
         app:nowLineDotRadius="5dp"
         app:nowLineStrokeWidth="1dp"
-        app:firstDayOfWeek="sunday"
+        app:firstDayOfWeek="monday"
         app:numberOfVisibleDays="7"
         app:overlappingEventGap="1dp"
         app:showFirstDayOfWeekFirst="true"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="title_activity_static">Basic Example (with static WeekView)</string>
     <string name="title_activity_asynchronous">Asynchronous Events</string>
     <string name="async_error">Could not download events from the internet</string>
+    <string name="date_infos">From %1$s to %2$s</string>
 </resources>


### PR DESCRIPTION
This PR contains :

- A correction to fix #25
- Improve the computation of the difference for the first display in week view for any first day
- The goToDate() in week view correctly display the first day wanted
- Change in the Basic Example (with static WeekView) to test the goToDate() function