### PR TITLE
FIX:  AllDay Chip leaves view on the right

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/HeaderRowDrawer.java
+++ b/library/src/main/java/com/alamkanak/weekview/HeaderRowDrawer.java
@@ -58,6 +58,21 @@ class HeaderRowDrawer<T> {
                 break;
             }
         }
+        //HOTFIX
+        if(!containsAllDayEvent){
+            if(drawConfig.currentOrigin.x%config.getTotalDayWidth()!=0){
+                final Calendar day = (Calendar) viewState.getFirstVisibleDay().clone();
+                day.add(DATE, config.numberOfVisibleDays+1);
+
+                for (int j = 0; j < eventChips.size(); j++) {
+                    final WeekViewEvent event = eventChips.get(j).event;
+                    if (event.isSameDay(day) && event.isAllDay()) {
+                        containsAllDayEvent = true;
+                        break;
+                    }
+                }
+            }
+        }
 
         drawConfig.hasEventInHeader = containsAllDayEvent;
         drawConfig.refreshHeaderHeight(config);

--- a/library/src/main/java/com/alamkanak/weekview/HeaderRowDrawer.java
+++ b/library/src/main/java/com/alamkanak/weekview/HeaderRowDrawer.java
@@ -60,9 +60,9 @@ class HeaderRowDrawer<T> {
         }
         //HOTFIX
         if(!containsAllDayEvent){
-            if(drawConfig.currentOrigin.x%config.getTotalDayWidth()!=0){
+            if(drawConfig.currentOrigin.x % config.getTotalDayWidth() != 0){
                 final Calendar day = (Calendar) viewState.getFirstVisibleDay().clone();
-                day.add(DATE, config.numberOfVisibleDays+1);
+                day.add(DATE, config.numberOfVisibleDays);
 
                 for (int j = 0; j < eventChips.size(); j++) {
                     final WeekViewEvent event = eventChips.get(j).event;


### PR DESCRIPTION
When an AllDay EventChip leaves the View on the right side, the last chip still gets displayed but the header hight is ignored (`hasEventInHeader=false`).

This is caused by the left entering Day set as the `FirstVisibleDay`

So `currentOrigin.x % getTotalDayWidth() != 0`  will tell us if we are currently in transmission and also have to check the `numberOfVisibleDays` day after the `FirstVisibleDay`

A bit hacky but working