### PR TITLE
FIX: zooming out reveals 00:00 to 01:00 segment at the bottom

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/WeekViewDrawingConfig.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekViewDrawingConfig.java
@@ -211,11 +211,14 @@ class WeekViewDrawingConfig {
 
     void refreshAfterZooming(WeekViewConfig config) {
         if (newHourHeight > 0 && !config.showCompleteDay) {
-            if (newHourHeight < config.effectiveMinHourHeight) {
-                newHourHeight = config.effectiveMinHourHeight;
-            } else if (newHourHeight > config.maxHourHeight) {
-                newHourHeight = config.maxHourHeight;
-            }
+            newHourHeight = Math.max(newHourHeight, config.effectiveMinHourHeight);
+            newHourHeight = Math.min(newHourHeight, config.maxHourHeight);
+
+            // potentialMinHourHeight
+            // needed to suppress the zooming below 24:00
+            final int height = WeekView.getViewHeight();
+            float potentialMinHourHeight = (height - headerHeight) / 24;
+            newHourHeight = Math.max(newHourHeight, potentialMinHourHeight);
 
             currentOrigin.y = (currentOrigin.y / config.hourHeight) * newHourHeight;
             config.hourHeight = newHourHeight;

--- a/library/src/main/java/com/alamkanak/weekview/WeekViewDrawingConfig.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekViewDrawingConfig.java
@@ -215,9 +215,10 @@ class WeekViewDrawingConfig {
             newHourHeight = Math.min(newHourHeight, config.maxHourHeight);
 
             // potentialMinHourHeight
+            // the minimal height of an hour when zoomed completely out
             // needed to suppress the zooming below 24:00
             final int height = WeekView.getViewHeight();
-            float potentialMinHourHeight = (height - headerHeight) / 24;
+            float potentialMinHourHeight = (height - headerHeight) / Constants.HOURS_PER_DAY;
             newHourHeight = Math.max(newHourHeight, potentialMinHourHeight);
 
             currentOrigin.y = (currentOrigin.y / config.hourHeight) * newHourHeight;
@@ -230,7 +231,7 @@ class WeekViewDrawingConfig {
         final int height = WeekView.getViewHeight();
 
         // If the new currentOrigin.y is invalid, make it valid.
-        final float dayHeight = config.hourHeight * 24;
+        final float dayHeight = config.hourHeight * Constants.HOURS_PER_DAY;
 
         final float potentialNewVerticalOrigin = height - (dayHeight + headerHeight);
 


### PR DESCRIPTION
Zooming far enough out will display the segment from 00:00 to 01:00 AM on the bottom of a day
// TODO: When an AllDayChip leaves the viewport it will reveal the free space below, displaying the 00:00 to 01:00AM segment