### PR TITLE
Performance optimizations

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/DayLabelDrawer.kt
+++ b/library/src/main/java/com/alamkanak/weekview/DayLabelDrawer.kt
@@ -6,11 +6,14 @@ import android.os.Build.VERSION_CODES.M
 import android.text.Layout
 import android.text.StaticLayout
 import android.text.TextPaint
+import android.util.SparseArray
 import org.threeten.bp.LocalDate
 
 internal class DayLabelDrawer(
         private val config: WeekViewConfigWrapper
 ) {
+
+    private val sparseArray = SparseArray<String>()
 
     fun draw(drawingContext: DrawingContext, canvas: Canvas) {
         drawingContext
@@ -21,7 +24,7 @@ internal class DayLabelDrawer(
     }
 
     private fun drawLabel(day: LocalDate, startPixel: Float, canvas: Canvas) {
-        val dayLabel = config.dateTimeInterpreter.interpretDate(day.toCalendar())
+        val dayLabel = sparseArray.get(day.dayOfMonth + day.monthValue + day.year, config.dateTimeInterpreter.interpretDate(day.toCalendar()))
         val x = startPixel + config.widthPerDay / 2
 
         val textPaint = if (day.isToday) {

--- a/library/src/main/java/com/alamkanak/weekview/DayLabelDrawer.kt
+++ b/library/src/main/java/com/alamkanak/weekview/DayLabelDrawer.kt
@@ -13,7 +13,7 @@ internal class DayLabelDrawer(
         private val config: WeekViewConfigWrapper
 ) {
 
-    private val sparseArray = SparseArray<String>()
+    private val dayLabelCache = SparseArray<String>()
 
     fun draw(drawingContext: DrawingContext, canvas: Canvas) {
         drawingContext
@@ -24,7 +24,10 @@ internal class DayLabelDrawer(
     }
 
     private fun drawLabel(day: LocalDate, startPixel: Float, canvas: Canvas) {
-        val dayLabel = sparseArray.get(day.dayOfMonth + day.monthValue + day.year, config.dateTimeInterpreter.interpretDate(day.toCalendar()))
+
+        val key = day.toEpochDay().toInt()
+        val dayLabel = dayLabelCache.get(key, provideDayLabel(day))
+
         val x = startPixel + config.widthPerDay / 2
 
         val textPaint = if (day.isToday) {
@@ -59,4 +62,10 @@ internal class DayLabelDrawer(
                 StaticLayout(dayLabel, textPaint, config.totalDayWidth.toInt(),
                         Layout.Alignment.ALIGN_CENTER, 1.0f, 0.0f, false)
             }
+
+    private fun provideDayLabel(day: LocalDate): String {
+        return config.dateTimeInterpreter.interpretDate(day.toCalendar()).also {
+            dayLabelCache.put(day.toEpochDay().toInt(), it)
+        }
+    }
 }

--- a/library/src/main/java/com/alamkanak/weekview/EventChip.java
+++ b/library/src/main/java/com/alamkanak/weekview/EventChip.java
@@ -43,7 +43,7 @@ class EventChip<T> {
      *
      * @param event         Represents the event which this instance of rectangle represents.
      * @param originalEvent The original event that was passed by the user.
-     * @param rect         The rectangle.
+     * @param rect          The rectangle.
      */
     EventChip(WeekViewEvent<T> event, WeekViewEvent<T> originalEvent, RectF rect) {
         this.event = event;
@@ -51,17 +51,17 @@ class EventChip<T> {
         this.originalEvent = originalEvent;
     }
 
-    void draw(WeekViewConfigWrapper config, Canvas canvas) {
-        draw(config, null, canvas);
+    void draw(WeekViewConfigWrapper config, Canvas canvas, Paint paint) {
+        draw(config, null, canvas, paint);
     }
 
-    void draw(WeekViewConfigWrapper config, @Nullable StaticLayout textLayout, Canvas canvas) {
+    void draw(WeekViewConfigWrapper config, @Nullable StaticLayout textLayout, Canvas canvas, Paint paint) {
         final float cornerRadius = config.getEventCornerRadius();
-        final Paint backgroundPaint = getBackgroundPaint(config);
-        canvas.drawRoundRect(rect, cornerRadius, cornerRadius, backgroundPaint);
+        setBackgroundPaint(config, paint);
+        canvas.drawRoundRect(rect, cornerRadius, cornerRadius, paint);
 
         if (event.hasBorder()) {
-            final Paint borderPaint = getBorderPaint();
+            setBorderPaint(paint);
             final int borderWidth = event.getBorderWidth();
 
             final RectF adjustedRect = new RectF(
@@ -69,11 +69,11 @@ class EventChip<T> {
                     rect.top + borderWidth / 2f,
                     rect.right - borderWidth / 2f,
                     rect.bottom - borderWidth / 2f);
-            canvas.drawRoundRect(adjustedRect, cornerRadius, cornerRadius, borderPaint);
+            canvas.drawRoundRect(adjustedRect, cornerRadius, cornerRadius, paint);
         }
 
         if (event.isNotAllDay()) {
-            drawCornersForMultiDayEvents(backgroundPaint, cornerRadius, canvas);
+            drawCornersForMultiDayEvents(paint, cornerRadius, canvas);
         }
 
         if (textLayout != null) {
@@ -123,18 +123,16 @@ class EventChip<T> {
         }
     }
 
-    private Paint getBackgroundPaint(WeekViewConfigWrapper config) {
-        final Paint paint = new Paint();
+    private void setBackgroundPaint(WeekViewConfigWrapper config, Paint paint) {
         paint.setColor(event.getColorOrDefault(config));
-        return paint;
+        paint.setStrokeWidth(0);
+        paint.setStyle(Paint.Style.FILL);
     }
 
-    private Paint getBorderPaint() {
-        final Paint paint = new Paint();
+    private void setBorderPaint(Paint paint) {
         paint.setColor(event.getBorderColor());
         paint.setStrokeWidth(event.getBorderWidth());
         paint.setStyle(Paint.Style.STROKE);
-        return paint;
     }
 
     private void calculateTextHeightAndDrawTitle(WeekViewConfigWrapper config, Canvas canvas) {

--- a/library/src/main/java/com/alamkanak/weekview/EventChip.java
+++ b/library/src/main/java/com/alamkanak/weekview/EventChip.java
@@ -163,7 +163,11 @@ class EventChip<T> {
         final int availableWidth = (int) (rect.right - rect.left - config.getEventPadding() * 2);
 
         // Get text dimensions.
-        if (availableWidth != availableWidthCache || availableHeight != availableHeightCache || layoutCache == null) {
+
+        final boolean didAvailableAreaChange = availableWidth != availableWidthCache || availableHeight != availableHeightCache;
+        final boolean isCached = layoutCache != null;
+
+        if (didAvailableAreaChange || !isCached) {
             final TextPaint textPaint = event.getTextPaint(config);
             StaticLayout textLayout = new StaticLayout(stringBuilder,
                     textPaint, availableWidth, ALIGN_NORMAL, 1.0f, 0.0f, false);

--- a/library/src/main/java/com/alamkanak/weekview/EventsDrawer.java
+++ b/library/src/main/java/com/alamkanak/weekview/EventsDrawer.java
@@ -30,7 +30,7 @@ class EventsDrawer<T> {
     }
 
     void drawSingleEvents(List<EventChip<T>> eventChips,
-                          DrawingContext drawingContext, Canvas canvas) {
+                          DrawingContext drawingContext, Canvas canvas, Paint paint) {
         float startPixel = drawingContext.getStartPixel();
 
         // Draw single events
@@ -41,7 +41,7 @@ class EventsDrawer<T> {
                 startPixel = startPixel + config.getEventMarginHorizontal();
             }
 
-            drawEventsForDate(eventChips, date, startPixel, canvas);
+            drawEventsForDate(eventChips, date, startPixel, canvas, paint);
 
             // In the next iteration, start from the next day.
             startPixel += config.getTotalDayWidth();
@@ -49,7 +49,7 @@ class EventsDrawer<T> {
     }
 
     private void drawEventsForDate(List<EventChip<T>> eventChips, LocalDate date,
-                                   float startFromPixel, Canvas canvas) {
+                                   float startFromPixel, Canvas canvas, Paint paint) {
         if (eventChips == null) {
             return;
         }
@@ -64,7 +64,7 @@ class EventsDrawer<T> {
             final RectF chipRect = rectCalculator.calculateSingleEvent(eventChip, startFromPixel);
             if (isValidSingleEventRect(chipRect)) {
                 eventChip.rect = chipRect;
-                eventChip.draw(config, canvas);
+                eventChip.draw(config, canvas, paint);
             } else {
                 eventChip.rect = null;
             }
@@ -129,7 +129,7 @@ class EventsDrawer<T> {
      * @param canvas         The canvas to draw upon.
      */
     void drawAllDayEvents(List<Pair<EventChip<T>, StaticLayout>> eventChips,
-                          Canvas canvas) {
+                          Canvas canvas, Paint paint) {
         if (eventChips == null) {
             return;
         }
@@ -137,7 +137,7 @@ class EventsDrawer<T> {
         for (Pair<EventChip<T>, StaticLayout> pair : eventChips) {
             EventChip<T> eventChip = pair.first;
             StaticLayout layout = pair.second;
-            eventChip.draw(config, layout, canvas);
+            eventChip.draw(config, layout, canvas, paint);
         }
 
         // Hide events when they are in the top left corner

--- a/library/src/main/java/com/alamkanak/weekview/HeaderRowDrawer.kt
+++ b/library/src/main/java/com/alamkanak/weekview/HeaderRowDrawer.kt
@@ -9,9 +9,9 @@ internal class HeaderRowDrawer<T>(
         private val viewState: WeekViewViewState
 ) {
 
-    fun draw(drawingContext: DrawingContext, canvas: Canvas) {
+    fun draw(drawingContext: DrawingContext, canvas: Canvas, paint: Paint) {
         calculateAvailableSpaceForHeader(drawingContext)
-        drawHeaderRow(canvas)
+        drawHeaderRow(canvas, paint)
     }
 
     private fun calculateAvailableSpaceForHeader(drawingContext: DrawingContext) {
@@ -37,7 +37,7 @@ internal class HeaderRowDrawer<T>(
         config.refreshHeaderHeight()
     }
 
-    private fun drawHeaderRow(canvas: Canvas) {
+    private fun drawHeaderRow(canvas: Canvas, paint: Paint) {
         val width = WeekView.getViewWidth()
 
         canvas.restore()
@@ -61,18 +61,16 @@ internal class HeaderRowDrawer<T>(
         canvas.save()
 
         if (config.showHeaderRowBottomLine) {
-            drawHeaderBottomLine(width, canvas)
+            drawHeaderBottomLine(width, canvas, paint)
         }
     }
 
-    private fun drawHeaderBottomLine(width: Int, canvas: Canvas) {
+    private fun drawHeaderBottomLine(width: Int, canvas: Canvas, paint: Paint) {
         val headerRowBottomLineWidth = config.headerRowBottomLinePaint.strokeWidth
         val topMargin = config.headerHeight - headerRowBottomLineWidth
 
-        val paint = Paint().apply {
-            strokeWidth = headerRowBottomLineWidth
-            color = config.headerRowBottomLinePaint.color
-        }
+        paint.strokeWidth = headerRowBottomLineWidth
+        paint.color = config.headerRowBottomLinePaint.color
 
         canvas.drawLine(0f, topMargin, width.toFloat(), topMargin, paint)
     }

--- a/library/src/main/java/com/alamkanak/weekview/TimeColumnDrawer.kt
+++ b/library/src/main/java/com/alamkanak/weekview/TimeColumnDrawer.kt
@@ -8,9 +8,9 @@ internal class TimeColumnDrawer(
 ) {
     private val times = SparseArray<String>()
 
-    fun prepareTimes() {
-        for (i in config.startHour until config.hoursPerDay step config.timeColumnHoursInterval) {
-            times.put(i, config.dateTimeInterpreter.interpretTime(i + config.minHour))
+    init {
+        for (hour in config.startHour until config.hoursPerDay step config.timeColumnHoursInterval) {
+            times.put(hour, config.dateTimeInterpreter.interpretTime(hour + config.minHour))
         }
     }
 
@@ -31,8 +31,8 @@ internal class TimeColumnDrawer(
         val hourLines = FloatArray(config.hoursPerDay * 4)
         val hourStep = config.timeColumnHoursInterval
 
-        for (i in startHour until config.hoursPerDay step hourStep) {
-            val heightOfHour = (config.hourHeight * i)
+        for (hour in startHour until config.hoursPerDay step hourStep) {
+            val heightOfHour = (config.hourHeight * hour)
             top = config.headerHeight + config.currentOrigin.y + heightOfHour
 
             // Draw the text if its y position is not outside of the visible area. The pivot point
@@ -46,10 +46,10 @@ internal class TimeColumnDrawer(
                     y += config.timeTextHeight / 2 + config.hourSeparatorPaint.strokeWidth + config.timeColumnPadding
                 }
 
-                canvas.drawText(times[i], x, y, config.timeTextPaint)
+                canvas.drawText(times[hour], x, y, config.timeTextPaint)
 
-                if (config.showTimeColumnHourSeparator && i > 0) {
-                    val j = i - 1
+                if (config.showTimeColumnHourSeparator && hour > 0) {
+                    val j = hour - 1
                     val yHoursLines = top
                     hourLines[j * 4] = 0f
                     hourLines[j * 4 + 1] = yHoursLines

--- a/library/src/main/java/com/alamkanak/weekview/TimeColumnDrawer.kt
+++ b/library/src/main/java/com/alamkanak/weekview/TimeColumnDrawer.kt
@@ -1,10 +1,18 @@
 package com.alamkanak.weekview
 
 import android.graphics.Canvas
+import android.util.SparseArray
 
 internal class TimeColumnDrawer(
         private val config: WeekViewConfigWrapper
 ) {
+    private val times = SparseArray<String>()
+
+    fun prepareTimes() {
+        for (i in config.startHour until config.hoursPerDay step config.timeColumnHoursInterval) {
+            times.put(i, config.dateTimeInterpreter.interpretTime(i + config.minHour))
+        }
+    }
 
     fun drawTimeColumn(canvas: Canvas) {
         var top = config.headerHeight
@@ -29,8 +37,6 @@ internal class TimeColumnDrawer(
 
             // Draw the text if its y position is not outside of the visible area. The pivot point
             // of the text is the point at the bottom-right corner.
-            val time = config.dateTimeInterpreter.interpretTime(i + config.minHour)
-
             if (top < bottom) {
                 val x = config.timeTextWidth + config.timeColumnPadding
                 var y = top + config.timeTextHeight / 2
@@ -40,11 +46,11 @@ internal class TimeColumnDrawer(
                     y += config.timeTextHeight / 2 + config.hourSeparatorPaint.strokeWidth + config.timeColumnPadding
                 }
 
-                canvas.drawText(time, x, y, config.timeTextPaint)
+                canvas.drawText(times[i], x, y, config.timeTextPaint)
 
                 if (config.showTimeColumnHourSeparator && i > 0) {
-                    val j = i-1
-                    val  yHoursLines = top
+                    val j = i - 1
+                    val yHoursLines = top
                     hourLines[j * 4] = 0f
                     hourLines[j * 4 + 1] = yHoursLines
                     hourLines[j * 4 + 2] = config.timeColumnWidth

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -89,8 +89,6 @@ public final class WeekView<T> extends View
 
         eventChipsProvider = new EventChipsProvider<>(configWrapper, cache, viewState);
         eventChipsProvider.setWeekViewLoader(getWeekViewLoader());
-
-        timeColumnDrawer.prepareTimes();
     }
 
     static int getViewWidth() {
@@ -170,7 +168,7 @@ public final class WeekView<T> extends View
         eventsDrawer.drawSingleEvents(cache.getNormalEventChips(), drawingContext, canvas, paint);
 
         nowLineDrawer.draw(drawingContext, canvas);
-        headerRowDrawer.draw(drawingContext, canvas);
+        headerRowDrawer.draw(drawingContext, canvas, paint);
         dayLabelDrawer.draw(drawingContext, canvas);
 
         eventsDrawer.drawAllDayEvents(allDayEvents, canvas, paint);

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -3,6 +3,7 @@ package com.alamkanak.weekview;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Canvas;
+import android.graphics.Paint;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
@@ -132,6 +133,8 @@ public final class WeekView<T> extends View
         }
     }
 
+    private final Paint paint = new Paint();
+
     @Override
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
@@ -162,13 +165,13 @@ public final class WeekView<T> extends View
         dayBackgroundDrawer.draw(drawingContext, canvas);
         backgroundGridDrawer.draw(drawingContext, canvas);
 
-        eventsDrawer.drawSingleEvents(cache.getNormalEventChips(), drawingContext, canvas);
+        eventsDrawer.drawSingleEvents(cache.getNormalEventChips(), drawingContext, canvas, paint);
 
         nowLineDrawer.draw(drawingContext, canvas);
         headerRowDrawer.draw(drawingContext, canvas);
         dayLabelDrawer.draw(drawingContext, canvas);
 
-        eventsDrawer.drawAllDayEvents(allDayEvents, canvas);
+        eventsDrawer.drawAllDayEvents(allDayEvents, canvas, paint);
         timeColumnDrawer.drawTimeColumn(canvas);
 
         if (isFirstDraw) {

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -89,6 +89,8 @@ public final class WeekView<T> extends View
 
         eventChipsProvider = new EventChipsProvider<>(configWrapper, cache, viewState);
         eventChipsProvider.setWeekViewLoader(getWeekViewLoader());
+
+        timeColumnDrawer.prepareTimes();
     }
 
     static int getViewWidth() {
@@ -699,7 +701,7 @@ public final class WeekView<T> extends View
      * and `pastBackgroundColor`.
      *
      * @param color True if past and future should have two different
-     *                                    background colors.
+     *              background colors.
      */
     public void setShowDistinctPastFutureColor(boolean color) {
         configWrapper.setShowDistinctPastFutureColor(color);


### PR DESCRIPTION
I've added some performance optimizations to the View, so that also with a lot of events, it can run smoothly:

- There is now only one Paint object, to save a lot of Objects instantiations.
- The Labels for the Days and Hours are now cached, so that they don't have to be parsed every `onDraw()` call.
- The `StaticLayout` of the `EventChip` is now cached, and will only be re-created, if the available space for that layout is changing.

I've tested the changes and didn't encounter any issues, beside the fact that the WeekView is now smoother (especially when using a large dataset of events)