### PR TITLE
Display location underneath title

### DIFF
--- a/core/src/main/java/com/alamkanak/weekview/EventChipDrawer.kt
+++ b/core/src/main/java/com/alamkanak/weekview/EventChipDrawer.kt
@@ -7,8 +7,6 @@ import android.graphics.RectF
 import android.graphics.Typeface
 import android.text.SpannableStringBuilder
 import android.text.StaticLayout
-import android.text.TextUtils.TruncateAt
-import android.text.TextUtils.ellipsize
 import android.text.style.StyleSpan
 import androidx.core.content.ContextCompat
 
@@ -86,7 +84,7 @@ internal class EventChipDrawer<T>(
         val borderEndX = borderStartX + innerWidth
 
         if (event.startsOnEarlierDay(originalEvent)) {
-            // Remove top border stroke
+            // Remove top rounded corners by drawing a rectangle
             val borderStartY = rect.top
             val borderEndY = borderStartY + borderWidth
             val newRect = RectF(borderStartX, borderStartY, borderEndX, borderEndY)
@@ -94,7 +92,7 @@ internal class EventChipDrawer<T>(
         }
 
         if (event.endsOnLaterDay(originalEvent)) {
-            // Remove bottom border stroke
+            // Remove bottom rounded corners by drawing a rectangle
             val borderEndY = rect.bottom
             val borderStartY = borderEndY - borderWidth
             val newRect = RectF(borderStartX, borderStartY, borderEndX, borderEndY)
@@ -154,29 +152,11 @@ internal class EventChipDrawer<T>(
             return
         }
 
-        // Get text dimensions.
         val didAvailableAreaChange = eventChip.didAvailableAreaChange(rect, config.eventPadding)
         val isCached = textLayoutCache.containsKey(event.id)
 
         if (didAvailableAreaChange || !isCached) {
-            val textPaint = event.getTextPaint(context, config)
-            val textLayout = TextLayoutBuilder.build(text, textPaint, chipWidth)
-            val lineHeight = textLayout.lineHeight
-
-            val fitsIntoChip = chipHeight >= lineHeight
-            val isAdaptive = config.adaptiveEventTextSize
-
-            val finalTextLayout = when {
-                // The text fits into the chip, so we just need to ellipsize it
-                fitsIntoChip ->
-                    ellipsizeTextToFitChip(eventChip, text, textLayout, chipHeight, chipWidth)
-                // The text doesn't fit into the chip, so we need to gradually reduce its size until
-                // it does
-                isAdaptive -> scaleTextIntoChip(eventChip, text, textLayout, chipHeight, chipWidth)
-                else -> textLayout
-            }
-
-            textLayoutCache[event.id] = finalTextLayout
+            textLayoutCache[event.id] = textFitter.fit(eventChip, text, chipHeight, chipWidth)
             eventChip.updateAvailableArea(chipWidth, chipHeight)
         }
 
@@ -186,87 +166,7 @@ internal class EventChipDrawer<T>(
         }
     }
 
-    private fun ellipsizeTextToFitChip(
-        eventChip: EventChip<T>,
-        text: SpannableStringBuilder,
-        staticLayout: StaticLayout,
-        availableHeight: Int,
-        availableWidth: Int
-    ): StaticLayout {
-        val event = eventChip.event
-        val rect = checkNotNull(eventChip.rect)
-
-        // The text fits into the chip, so we just need to ellipsize it
-        var textLayout = staticLayout
-
-        val textPaint = event.getTextPaint(context, config)
-        var availableLineCount = availableHeight / textLayout.lineHeight
-
-        // val modifiedText = titleBuilder.build(event, singleLine = true)
-
-        val modifiedText = when {
-            // Draw location behind title instead of underneath it to save space
-            textLayout.height > availableHeight -> replaceNewLineWithSpace(text)
-            else -> text
-        }
-
-        do {
-            // Ellipsize text to fit into event rect.
-            val availableArea = availableLineCount * availableWidth * 1f
-            val ellipsized = ellipsize(modifiedText, textPaint, availableArea, TruncateAt.END)
-
-            val width = (rect.right - rect.left - (config.eventPadding * 2).toFloat()).toInt()
-            textLayout = TextLayoutBuilder.build(ellipsized, textPaint, width)
-
-            // Repeat until text is short enough.
-            availableLineCount--
-        } while (textLayout.height > availableHeight)
-
-        return textLayout
-    }
-
-    private fun replaceNewLineWithSpace(
-        text: CharSequence
-    ): CharSequence {
-        val (title, location) = text.split("\n").toPair()
-        val modifiedText = SpannableStringBuilder(title)
-        modifiedText.setSpan(StyleSpan(Typeface.BOLD))
-
-        if (location.isNotEmpty()) {
-            modifiedText.append(" ")
-            modifiedText.append(location)
-        }
-
-        return modifiedText
-    }
-
-    private fun scaleTextIntoChip(
-        eventChip: EventChip<T>,
-        text: CharSequence,
-        staticLayout: StaticLayout,
-        availableHeight: Int,
-        availableWidth: Int
-    ): StaticLayout {
-        val event = eventChip.event
-        val rect = checkNotNull(eventChip.rect)
-
-        // The text doesn't fit into the chip, so we need to gradually reduce its size until it does
-        var textLayout = staticLayout
-        val textPaint = event.getTextPaint(context, config)
-
-        do {
-            textPaint.textSize -= 1f
-
-            val adaptiveLineCount = availableHeight / textLayout.lineHeight
-            val availableArea = adaptiveLineCount * availableWidth
-            val ellipsized = ellipsize(text, textPaint, availableArea.toFloat(), TruncateAt.END)
-
-            val width = (rect.right - rect.left - (config.eventPadding * 2).toFloat()).toInt()
-            textLayout = TextLayoutBuilder.build(ellipsized, textPaint, width)
-        } while (availableHeight <= textLayout.height)
-
-        return textLayout
-    }
+    private val textFitter = TextFitter<T>(context, config)
 
     private fun setBackgroundPaint(
         event: WeekViewEvent<T>,
@@ -294,10 +194,5 @@ internal class EventChipDrawer<T>(
         paint.isAntiAlias = true
         paint.strokeWidth = event.style.borderWidth.toFloat()
         paint.style = Paint.Style.STROKE
-    }
-
-    private fun <T> List<T>.toPair(): Pair<T, T> {
-        check(size == 2)
-        return first() to last()
     }
 }

--- a/core/src/main/java/com/alamkanak/weekview/StaticLayoutExtensions.kt
+++ b/core/src/main/java/com/alamkanak/weekview/StaticLayoutExtensions.kt
@@ -1,6 +1,0 @@
-package com.alamkanak.weekview
-
-import android.text.StaticLayout
-
-internal val StaticLayout.lineHeight: Int
-    get() = height / lineCount

--- a/core/src/main/java/com/alamkanak/weekview/TextExtensions.kt
+++ b/core/src/main/java/com/alamkanak/weekview/TextExtensions.kt
@@ -1,0 +1,12 @@
+package com.alamkanak.weekview
+
+import android.text.SpannableStringBuilder
+import android.text.StaticLayout
+import android.text.style.StyleSpan
+
+internal val StaticLayout.lineHeight: Int
+    get() = height / lineCount
+
+internal fun SpannableStringBuilder.setSpan(
+    styleSpan: StyleSpan
+) = setSpan(styleSpan, 0, length, 0)

--- a/core/src/main/java/com/alamkanak/weekview/TextFitter.kt
+++ b/core/src/main/java/com/alamkanak/weekview/TextFitter.kt
@@ -108,7 +108,7 @@ internal class TextFitter<T>(
     }
 
     private fun <T> List<T>.toPair(): Pair<T, T> {
-        check(size == 2) { "Error: $this" }
+        check(size == 2)
         return first() to last()
     }
 }

--- a/core/src/main/java/com/alamkanak/weekview/TextFitter.kt
+++ b/core/src/main/java/com/alamkanak/weekview/TextFitter.kt
@@ -1,0 +1,114 @@
+package com.alamkanak.weekview
+
+import android.content.Context
+import android.graphics.Typeface
+import android.text.SpannableStringBuilder
+import android.text.StaticLayout
+import android.text.TextUtils.TruncateAt
+import android.text.TextUtils.ellipsize
+import android.text.style.StyleSpan
+
+internal class TextFitter<T>(
+    private val context: Context,
+    private val config: WeekViewConfigWrapper
+) {
+
+    fun fit(
+        eventChip: EventChip<T>,
+        text: SpannableStringBuilder,
+        chipHeight: Int,
+        chipWidth: Int
+    ): StaticLayout {
+        val textPaint = eventChip.event.getTextPaint(context, config)
+        val textLayout = TextLayoutBuilder.build(text, textPaint, chipWidth)
+
+        val fitsIntoChip = chipHeight >= textLayout.height
+        if (fitsIntoChip) {
+            return textLayout.ellipsize(eventChip, text, chipHeight, chipWidth)
+        }
+
+        val isMultiLine = text.contains("\n")
+        val finalText = if (isMultiLine) text.replaceNewLineWithSpace() else text
+
+        val fitsIntoChipNow = chipHeight >= textLayout.height
+        val isAdaptive = config.adaptiveEventTextSize
+
+        return when {
+            fitsIntoChipNow -> textLayout.ellipsize(eventChip, finalText, chipHeight, chipWidth)
+            isAdaptive -> textLayout.scaleToFit(eventChip, finalText, chipHeight, chipWidth)
+            else -> textLayout
+        }
+    }
+
+    private fun StaticLayout.ellipsize(
+        eventChip: EventChip<T>,
+        text: SpannableStringBuilder,
+        availableHeight: Int,
+        availableWidth: Int
+    ): StaticLayout {
+        val event = eventChip.event
+        val rect = checkNotNull(eventChip.rect)
+
+        // The text fits into the chip, so we just need to ellipsize it
+        var textLayout = this
+        val textPaint = event.getTextPaint(context, config)
+
+        var availableLineCount = availableHeight / textLayout.lineHeight
+        val width = (rect.right - rect.left - (config.eventPadding * 2).toFloat()).toInt()
+
+        do {
+            // Ellipsize text to fit into event rect
+            val availableArea = availableLineCount * availableWidth * 1f
+            val ellipsized = ellipsize(text, textPaint, availableArea, TruncateAt.END)
+            textLayout = TextLayoutBuilder.build(ellipsized, textPaint, width)
+            availableLineCount--
+        } while (textLayout.height > availableHeight)
+
+        return textLayout
+    }
+
+    private fun SpannableStringBuilder.replaceNewLineWithSpace(): SpannableStringBuilder {
+        val (title, location) = split("\n").toPair()
+        val modifiedText = SpannableStringBuilder(title)
+        modifiedText.setSpan(StyleSpan(Typeface.BOLD))
+
+        if (location.isNotEmpty()) {
+            modifiedText.append(" ")
+            modifiedText.append(location)
+        }
+
+        return modifiedText
+    }
+
+    private fun StaticLayout.scaleToFit(
+        eventChip: EventChip<T>,
+        text: SpannableStringBuilder,
+        availableHeight: Int,
+        availableWidth: Int
+    ): StaticLayout {
+        val event = eventChip.event
+        val rect = checkNotNull(eventChip.rect)
+
+        // The text doesn't fit into the chip, so we need to gradually reduce its size until it does
+        var textLayout = this
+        val textPaint = event.getTextPaint(context, config)
+
+        do {
+            textPaint.textSize -= 1f
+
+            val adaptiveLineCount = availableHeight / textLayout.lineHeight
+            val availableArea = adaptiveLineCount * availableWidth * 1f
+            val ellipsized = ellipsize(text, textPaint, availableArea, TruncateAt.END)
+
+            val width = (rect.right - rect.left - (config.eventPadding * 2).toFloat()).toInt()
+            textLayout = TextLayoutBuilder.build(ellipsized, textPaint, width)
+        } while (availableHeight < textLayout.height)
+
+        return textLayout
+    }
+
+    private fun <T> List<T>.toPair(): Pair<T, T> {
+        check(size == 2) { "Error: $this" }
+        return first() to last()
+    }
+}

--- a/sample/src/main/java/com/alamkanak/weekview/sample/data/EventsDatabase.kt
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/data/EventsDatabase.kt
@@ -183,7 +183,8 @@ class FakeEventsDatabase(private val context: Context) : EventsDatabase {
         color: Int,
         isAllDay: Boolean,
         isCanceled: Boolean
-    ) = Event(id, getEventTitle(startTime), startTime, endTime, "", color, isAllDay, isCanceled)
+    ) = Event(id, getEventTitle(startTime), startTime,
+        endTime, "Location $id", color, isAllDay, isCanceled)
 
     private fun getEventTitle(time: Calendar): String {
         val sdf = SimpleDateFormat.getDateInstance(DateFormat.MEDIUM)


### PR DESCRIPTION
With this change, the location of an event will now be displayed underneath the title. If the height of the event chip is too small, the location will be displayed behind the title. 

Related issue: #21 

| **Before**  | **After** |
| ------------- | ------------- |
| ![Screenshot_1564076676](https://user-images.githubusercontent.com/11819826/61896269-e48a8200-af14-11e9-898b-be136f1914da.png) | ![Screenshot_1564076621](https://user-images.githubusercontent.com/11819826/61896295-efddad80-af14-11e9-816b-626e2bebddae.png) |