### PR TITLE
Add option to use dimension resource for border width of an EventChip

### DIFF
--- a/core/src/main/java/com/alamkanak/weekview/EventChipDrawer.kt
+++ b/core/src/main/java/com/alamkanak/weekview/EventChipDrawer.kt
@@ -11,6 +11,8 @@ import android.text.TextUtils.TruncateAt
 import android.text.TextUtils.ellipsize
 import android.text.style.StyleSpan
 import androidx.core.content.ContextCompat
+import com.alamkanak.weekview.WeekViewEvent.ColorResource
+import com.alamkanak.weekview.WeekViewEvent.TextResource
 
 internal class EventChipDrawer<T>(
     private val context: Context,
@@ -35,8 +37,8 @@ internal class EventChipDrawer<T>(
 
         if (event.style.hasBorder) {
             setBorderPaint(event, paint)
-            val borderWidth = event.style.borderWidth
 
+            val borderWidth = event.style.getBorderWidth(context)
             val adjustedRect = RectF(
                 rect.left + borderWidth / 2f,
                 rect.top + borderWidth / 2f,
@@ -79,7 +81,7 @@ internal class EventChipDrawer<T>(
             return
         }
 
-        val borderWidth = event.style.borderWidth.toFloat()
+        val borderWidth = event.style.getBorderWidth(context)
         val innerWidth = rect.width() - borderWidth * 2
 
         val borderStartX = rect.left + borderWidth
@@ -130,8 +132,8 @@ internal class EventChipDrawer<T>(
         }
 
         val title = when (val resource = event.titleResource) {
-            is WeekViewEvent.TextResource.Id -> context.getString(resource.resId)
-            is WeekViewEvent.TextResource.Value -> resource.text
+            is TextResource.Id -> context.getString(resource.resId)
+            is TextResource.Value -> resource.text
             null -> throw IllegalStateException("Invalid title resource: $resource")
         }
 
@@ -139,8 +141,8 @@ internal class EventChipDrawer<T>(
         text.setSpan(StyleSpan(Typeface.BOLD), 0, text.length, 0)
 
         val location = when (val resource = event.locationResource) {
-            is WeekViewEvent.TextResource.Id -> context.getString(resource.resId)
-            is WeekViewEvent.TextResource.Value -> resource.text
+            is TextResource.Id -> context.getString(resource.resId)
+            is TextResource.Value -> resource.text
             null -> null
         }
 
@@ -252,8 +254,8 @@ internal class EventChipDrawer<T>(
     ) {
         val resource = event.style.getBackgroundColorOrDefault(config)
         paint.color = when (resource) {
-            is WeekViewEvent.ColorResource.Id -> ContextCompat.getColor(context, resource.resId)
-            is WeekViewEvent.ColorResource.Value -> resource.color
+            is ColorResource.Id -> ContextCompat.getColor(context, resource.resId)
+            is ColorResource.Value -> resource.color
         }
         paint.isAntiAlias = true
         paint.strokeWidth = 0f
@@ -265,12 +267,12 @@ internal class EventChipDrawer<T>(
         paint: Paint
     ) {
         paint.color = when (val resource = event.style.borderColorResource) {
-            is WeekViewEvent.ColorResource.Id -> ContextCompat.getColor(context, resource.resId)
-            is WeekViewEvent.ColorResource.Value -> resource.color
+            is ColorResource.Id -> ContextCompat.getColor(context, resource.resId)
+            is ColorResource.Value -> resource.color
             null -> 0
         }
         paint.isAntiAlias = true
-        paint.strokeWidth = event.style.borderWidth.toFloat()
+        paint.strokeWidth = event.style.getBorderWidth(context).toFloat()
         paint.style = Paint.Style.STROKE
     }
 }

--- a/sample/src/main/java/com/alamkanak/weekview/sample/apiclient/Event.kt
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/apiclient/Event.kt
@@ -3,6 +3,7 @@ package com.alamkanak.weekview.sample.apiclient
 import android.graphics.Color
 import com.alamkanak.weekview.WeekViewDisplayable
 import com.alamkanak.weekview.WeekViewEvent
+import com.alamkanak.weekview.sample.R
 import java.util.Calendar
 
 class Event(
@@ -19,25 +20,25 @@ class Event(
     override fun toWeekViewEvent(): WeekViewEvent<Event> {
         val backgroundColor = if (!isCanceled) color else Color.WHITE
         val textColor = if (!isCanceled) Color.WHITE else color
-        val borderWidth = if (!isCanceled) 0 else 4
+        val borderWidthResId = if (!isCanceled) R.dimen.no_border_width else R.dimen.border_width
 
         val style = WeekViewEvent.Style.Builder()
-                .setTextColor(textColor)
-                .setBackgroundColor(backgroundColor)
-                .setTextStrikeThrough(isCanceled)
-                .setBorderWidth(borderWidth)
-                .setBorderColor(color)
-                .build()
+            .setTextColor(textColor)
+            .setBackgroundColor(backgroundColor)
+            .setTextStrikeThrough(isCanceled)
+            .setBorderWidthResource(borderWidthResId)
+            .setBorderColor(color)
+            .build()
 
         return WeekViewEvent.Builder<Event>()
-                .setId(id)
-                .setTitle(title)
-                .setStartTime(startTime)
-                .setEndTime(endTime)
-                .setLocation(location)
-                .setAllDay(isAllDay)
-                .setStyle(style)
-                .setData(this)
-                .build()
+            .setId(id)
+            .setTitle(title)
+            .setStartTime(startTime)
+            .setEndTime(endTime)
+            .setLocation(location)
+            .setAllDay(isAllDay)
+            .setStyle(style)
+            .setData(this)
+            .build()
     }
 }

--- a/sample/src/main/res/values/dimens.xml
+++ b/sample/src/main/res/values/dimens.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="default_space">16dp</dimen>
+    <dimen name="border_width">1dp</dimen>
+    <dimen name="no_border_width">0dp</dimen>
 </resources>


### PR DESCRIPTION
In addition to `WeekViewEvent.Style.Builder.setBorderWidth(Int)`, you can now use `WeekViewEvent.Style.setBorderWidthResource(Int)` to specify a value from a `dimens.xml` resource file that should be used for the border width.