### PR TITLE
Fix crash issue: TypeCastException when construct SaveState(#143)

### DIFF
--- a/core/src/main/java/com/alamkanak/weekview/SavedState.kt
+++ b/core/src/main/java/com/alamkanak/weekview/SavedState.kt
@@ -23,7 +23,7 @@ internal class SavedState : BaseSavedState {
 
     constructor(source: Parcel) : super(source) {
         numberOfVisibleDays = source.readInt()
-        firstVisibleDate = source.readSerializable() as Calendar
+        firstVisibleDate = source.readSerializable() as? Calendar
     }
 
     override fun writeToParcel(out: Parcel, flags: Int) {


### PR DESCRIPTION
Issue #143, Stack here:
Caused by kotlin.TypeCastException
null cannot be cast to non-null type java.util.Calendar