### PR TITLE
Add better scrolling

### DIFF
--- a/core/src/main/java/com/alamkanak/weekview/CalendarExtensions.kt
+++ b/core/src/main/java/com/alamkanak/weekview/CalendarExtensions.kt
@@ -25,11 +25,17 @@ internal inline class Millis(val millis: Int) : Duration {
         get() = millis
 }
 
-internal val Calendar.hour: Int
+internal var Calendar.hour: Int
     get() = get(Calendar.HOUR_OF_DAY)
+    set(value) {
+        set(Calendar.HOUR_OF_DAY, value)
+    }
 
-internal val Calendar.minute: Int
+internal var Calendar.minute: Int
     get() = get(Calendar.MINUTE)
+    set(value) {
+        set(Calendar.MINUTE, value)
+    }
 
 internal val Calendar.dayOfWeek: Int
     get() = get(Calendar.DAY_OF_WEEK)
@@ -257,4 +263,14 @@ internal fun Calendar.format(
 ): String {
     val sdf = SimpleDateFormat.getDateInstance(format)
     return sdf.format(time)
+}
+
+internal fun Calendar.limitBy(minTime: Calendar, maxTime: Calendar) {
+    if (this < minTime) {
+        hour = minTime.hour
+        minute = 0
+    } else if (this > maxTime) {
+        hour = maxTime.hour
+        minute = 0
+    }
 }

--- a/core/src/main/java/com/alamkanak/weekview/PublicApi.kt
+++ b/core/src/main/java/com/alamkanak/weekview/PublicApi.kt
@@ -1,0 +1,3 @@
+package com.alamkanak.weekview
+
+annotation class PublicApi

--- a/core/src/main/java/com/alamkanak/weekview/SavedState.kt
+++ b/core/src/main/java/com/alamkanak/weekview/SavedState.kt
@@ -8,14 +8,14 @@ import java.util.Calendar
 internal class SavedState : BaseSavedState {
 
     var numberOfVisibleDays: Int = 0
-    var firstVisibleDate: Calendar? = null
+    var firstVisibleDate: Calendar = today()
 
     constructor(superState: Parcelable) : super(superState)
 
     constructor(
         superState: Parcelable,
         numberOfVisibleDays: Int,
-        firstVisibleDate: Calendar?
+        firstVisibleDate: Calendar
     ) : super(superState) {
         this.numberOfVisibleDays = numberOfVisibleDays
         this.firstVisibleDate = firstVisibleDate
@@ -23,7 +23,7 @@ internal class SavedState : BaseSavedState {
 
     constructor(source: Parcel) : super(source) {
         numberOfVisibleDays = source.readInt()
-        firstVisibleDate = source.readSerializable() as? Calendar
+        firstVisibleDate = source.readSerializable() as Calendar
     }
 
     override fun writeToParcel(out: Parcel, flags: Int) {

--- a/core/src/main/java/com/alamkanak/weekview/ScaleGestureDetector.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ScaleGestureDetector.kt
@@ -1,0 +1,39 @@
+package com.alamkanak.weekview
+
+import android.content.Context
+import android.view.MotionEvent
+import android.view.ScaleGestureDetector as AndroidScaleGestureDetector
+
+internal class ScaleGestureDetector(
+    context: Context,
+    private val config: WeekViewConfigWrapper,
+    private val valueAnimator: ValueAnimator,
+    private val onInvalidation: () -> Unit
+) {
+
+    private val listener = object : AndroidScaleGestureDetector.OnScaleGestureListener {
+
+        override fun onScaleBegin(
+            detector: AndroidScaleGestureDetector
+        ): Boolean = !valueAnimator.isRunning
+
+        override fun onScale(detector: AndroidScaleGestureDetector): Boolean {
+            val hourHeight = config.hourHeight
+            config.newHourHeight = hourHeight * detector.scaleFactor
+            onInvalidation()
+            return true
+        }
+
+        override fun onScaleEnd(detector: AndroidScaleGestureDetector) {
+            onInvalidation()
+        }
+    }
+
+    private val detector = AndroidScaleGestureDetector(context, listener)
+
+    fun onTouchEvent(event: MotionEvent) {
+        if (!valueAnimator.isRunning) {
+            detector.onTouchEvent(event)
+        }
+    }
+}

--- a/core/src/main/java/com/alamkanak/weekview/TimeColumnDrawer.kt
+++ b/core/src/main/java/com/alamkanak/weekview/TimeColumnDrawer.kt
@@ -15,8 +15,8 @@ internal class TimeColumnDrawer(
     }
 
     private fun cacheTimeLabels() = with(config) {
-        for (hour in minHour..maxHour step timeColumnHoursInterval) {
-            timeLabelCache.put(hour, dateTimeInterpreter.interpretTime(hour + minHour))
+        for (hour in timeRange step timeColumnHoursInterval) {
+            timeLabelCache.put(hour, dateTimeInterpreter.interpretTime(hour))
         }
     }
 
@@ -32,7 +32,7 @@ internal class TimeColumnDrawer(
         val hourLines = FloatArray(hoursPerDay * 4)
         val hourStep = timeColumnHoursInterval
 
-        for (hour in startHour until hoursPerDay step hourStep) {
+        for (hour in timeRange step hourStep) {
             val heightOfHour = hourHeight * (hour - minHour)
             topMargin = headerHeight + currentOrigin.y + heightOfHour
 
@@ -49,7 +49,9 @@ internal class TimeColumnDrawer(
                 y += timeTextHeight / 2 + hourSeparatorPaint.strokeWidth + timeColumnPadding
             }
 
-            canvas.drawText(timeLabelCache[hour], x, y, timeTextPaint)
+            if (hour in timeLabelCache) {
+                canvas.drawText(timeLabelCache[hour], x, y, timeTextPaint)
+            }
 
             if (showTimeColumnHourSeparator && hour > 0) {
                 val j = hour - 1
@@ -77,3 +79,5 @@ internal class TimeColumnDrawer(
         cacheTimeLabels()
     }
 }
+
+private operator fun <E> SparseArray<E>.contains(key: Int): Boolean = indexOfKey(key) >= 0

--- a/core/src/main/java/com/alamkanak/weekview/TimeColumnDrawer.kt
+++ b/core/src/main/java/com/alamkanak/weekview/TimeColumnDrawer.kt
@@ -15,7 +15,7 @@ internal class TimeColumnDrawer(
     }
 
     private fun cacheTimeLabels() = with(config) {
-        for (hour in startHour until hoursPerDay step timeColumnHoursInterval) {
+        for (hour in minHour..maxHour step timeColumnHoursInterval) {
             timeLabelCache.put(hour, dateTimeInterpreter.interpretTime(hour + minHour))
         }
     }
@@ -33,7 +33,7 @@ internal class TimeColumnDrawer(
         val hourStep = timeColumnHoursInterval
 
         for (hour in startHour until hoursPerDay step hourStep) {
-            val heightOfHour = (hourHeight * hour)
+            val heightOfHour = hourHeight * (hour - minHour)
             topMargin = headerHeight + currentOrigin.y + heightOfHour
 
             val isOutsideVisibleArea = topMargin > bottom

--- a/core/src/main/java/com/alamkanak/weekview/ValueAnimator.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ValueAnimator.kt
@@ -1,0 +1,53 @@
+package com.alamkanak.weekview
+
+import android.animation.Animator
+import android.animation.ValueAnimator as AndroidValueAnimator
+import android.view.animation.DecelerateInterpolator
+
+internal class ValueAnimator {
+
+    private var valueAnimator: AndroidValueAnimator? = null
+
+    val isRunning: Boolean
+        get() = valueAnimator?.isStarted ?: false
+
+    fun animate(
+        fromValue: Float,
+        toValue: Float,
+        duration: Long = 300,
+        onUpdate: (Float) -> Unit,
+        onEnd: () -> Unit = {}
+    ) {
+        valueAnimator?.cancel()
+
+        valueAnimator = AndroidValueAnimator.ofFloat(fromValue, toValue).apply {
+            setDuration(duration)
+            interpolator = DecelerateInterpolator()
+
+            addUpdateListener {
+                val value = it.animatedValue as Float
+                onUpdate(value)
+            }
+
+            addEndListener { onEnd() }
+
+            start()
+        }
+    }
+
+    fun stop() {
+        valueAnimator?.cancel()
+    }
+}
+
+private fun AndroidValueAnimator.addEndListener(listener: (AndroidValueAnimator) -> Unit) {
+    addListener(object : Animator.AnimatorListener {
+        override fun onAnimationStart(animator: Animator) {
+            listener(animator as AndroidValueAnimator)
+        }
+
+        override fun onAnimationEnd(animator: Animator) = Unit
+        override fun onAnimationCancel(animator: Animator) = Unit
+        override fun onAnimationRepeat(animator: Animator) = Unit
+    })
+}

--- a/core/src/main/java/com/alamkanak/weekview/WeekView.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekView.kt
@@ -1192,7 +1192,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
             return
         }
 
-        if (hour !in configWrapper.timeRange) {
+        if (hour !in configWrapper.minHour..configWrapper.maxHour) {
             throw IllegalArgumentException(
                 "The provided hour ($hour) is outside of the set time range " +
                     "(${configWrapper.minHour} – ${configWrapper.maxHour})"

--- a/core/src/main/java/com/alamkanak/weekview/WeekView.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekView.kt
@@ -27,21 +27,30 @@ class WeekView<T : Any> @JvmOverloads constructor(
         WeekViewConfigWrapper(this, config)
     }
 
-    private val gestureListener = object : WeekViewGestureHandler.Listener {
-        override fun requireInvalidation() = ViewCompat.postInvalidateOnAnimation(this@WeekView)
-    }
-
     private val cache = WeekViewCache<T>()
     private val eventChipCache = EventChipCache<T>()
 
     private val viewState = WeekViewViewState(configWrapper, this)
     private val drawingContext = DrawingContext(configWrapper)
 
-    private val gestureHandler =
-        WeekViewGestureHandler(this, configWrapper, eventChipCache, gestureListener)
+    private val touchHandler = WeekViewTouchHandler(configWrapper, eventChipCache)
+    private val gestureHandler = WeekViewGestureHandler(
+        view = this,
+        config = configWrapper,
+        viewState = viewState,
+        chipCache = eventChipCache,
+        touchHandler = touchHandler,
+        onInvalidation = { ViewCompat.postInvalidateOnAnimation(this) }
+    )
 
     private var accessibilityTouchHelper = WeekViewAccessibilityTouchHelper(
-        this, configWrapper, drawingContext, gestureHandler, eventChipCache)
+        view = this,
+        config = configWrapper,
+        drawingContext = drawingContext,
+        gestureHandler = gestureHandler,
+        touchHandler = touchHandler,
+        eventChipCache = eventChipCache
+    )
 
     private val eventChipsLoader = EventChipsLoader(configWrapper, eventChipCache)
     private val eventChipsExpander = EventChipsExpander(configWrapper, eventChipCache)
@@ -216,6 +225,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * [java.util.Calendar.WEDNESDAY], [java.util.Calendar.THURSDAY],
      * [java.util.Calendar.FRIDAY], [java.util.Calendar.SATURDAY].
      */
+    @PublicApi
     var firstDayOfWeek: Int
         get() = configWrapper.firstDayOfWeek
         set(value) {
@@ -226,6 +236,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the number of visible days.
      */
+    @PublicApi
     var numberOfVisibleDays: Int
         get() = configWrapper.numberOfVisibleDays
         set(value) {
@@ -244,6 +255,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns whether the first day of the week should be displayed at the left-most position
      * when WeekView is displayed for the first time.
      */
+    @PublicApi
     var isShowFirstDayOfWeekFirst: Boolean
         get() = configWrapper.showFirstDayOfWeekFirst
         set(value) {
@@ -258,6 +270,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      ***********************************************************************************************
      */
 
+    @PublicApi
     var isShowHeaderRowBottomLine: Boolean
         /**
          * Returns whether a horizontal line should be displayed at the bottom of the header row.
@@ -271,6 +284,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
             invalidate()
         }
 
+    @PublicApi
     var headerRowBottomLineColor: Int
         /**
          * Returns the color of the horizontal line at the bottom of the header row.
@@ -285,6 +299,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
             invalidate()
         }
 
+    @PublicApi
     var headerRowBottomLineWidth: Int
         /**
          * Returns the stroke width of the horizontal line at the bottom of the header row.
@@ -310,6 +325,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the padding in the time column to the left and right side of the time label.
      */
+    @PublicApi
     var timeColumnPadding: Int
         get() = configWrapper.timeColumnPadding
         set(value) {
@@ -320,6 +336,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the text color of the labels in the time column.
      */
+    @PublicApi
     var timeColumnTextColor: Int
         get() = configWrapper.timeColumnTextColor
         set(value) {
@@ -330,6 +347,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the background color of the time column.
      */
+    @PublicApi
     var timeColumnBackgroundColor: Int
         get() = configWrapper.timeColumnBackgroundColor
         set(value) {
@@ -340,6 +358,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the text size of the labels in the time column.
      */
+    @PublicApi
     var timeColumnTextSize: Int
         get() = configWrapper.timeColumnTextSize
         set(value) {
@@ -351,6 +370,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns whether the label for the midnight hour is displayed in the time column. This setting
      * is only considered if [isShowTimeColumnHourSeparator] is set to true.
      */
+    @PublicApi
     var isShowMidnightHour: Boolean
         get() = configWrapper.showMidnightHour
         set(value) {
@@ -361,6 +381,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns whether a horizontal line is displayed for each hour in the time column.
      */
+    @PublicApi
     var isShowTimeColumnHourSeparator: Boolean
         get() = configWrapper.showTimeColumnHourSeparator
         set(value) {
@@ -371,6 +392,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the interval in which time labels are displayed in the time column.
      */
+    @PublicApi
     var timeColumnHoursInterval: Int
         get() = configWrapper.timeColumnHoursInterval
         set(value) {
@@ -389,6 +411,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns whether a vertical line is displayed at the end of the time column.
      */
+    @PublicApi
     var isShowTimeColumnSeparator: Boolean
         get() = configWrapper.showTimeColumnSeparator
         set(value) {
@@ -399,6 +422,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the color of the time column separator.
      */
+    @PublicApi
     var timeColumnSeparatorColor: Int
         get() = configWrapper.timeColumnSeparatorColor
         set(value) {
@@ -409,6 +433,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the stroke width of the time column separator.
      */
+    @PublicApi
     var timeColumnSeparatorWidth: Int
         get() = configWrapper.timeColumnSeparatorStrokeWidth
         set(value) {
@@ -427,6 +452,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the header row padding, which is applied above and below the all-day event chips.
      */
+    @PublicApi
     var headerRowPadding: Int
         get() = configWrapper.headerRowPadding
         set(value) {
@@ -437,6 +463,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the header row background color.
      */
+    @PublicApi
     var headerRowBackgroundColor: Int
         get() = configWrapper.headerRowBackgroundColor
         set(value) {
@@ -447,6 +474,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the text color used for all date labels except today.
      */
+    @PublicApi
     var headerRowTextColor: Int
         get() = configWrapper.headerRowTextColor
         set(value) {
@@ -457,6 +485,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the text color used for today's date label.
      */
+    @PublicApi
     var todayHeaderTextColor: Int
         get() = configWrapper.todayHeaderTextColor
         set(value) {
@@ -467,6 +496,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the text size of all date labels.
      */
+    @PublicApi
     var headerRowTextSize: Int
         get() = configWrapper.headerRowTextSize
         set(value) {
@@ -485,6 +515,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the corner radius of an [EventChip].
      */
+    @PublicApi
     var eventCornerRadius: Int
         get() = configWrapper.eventCornerRadius
         set(value) {
@@ -495,6 +526,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the text size of a single-event [EventChip].
      */
+    @PublicApi
     var eventTextSize: Int
         get() = configWrapper.eventTextPaint.textSize.toInt()
         set(value) {
@@ -505,6 +537,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns whether the text size of the [EventChip] is adapting to the [EventChip] height.
      */
+    @PublicApi
     var isAdaptiveEventTextSize: Boolean
         get() = configWrapper.adaptiveEventTextSize
         set(value) {
@@ -515,6 +548,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the text size of an all-day [EventChip].
      */
+    @PublicApi
     var allDayEventTextSize: Int
         get() = configWrapper.allDayEventTextPaint.textSize.toInt()
         set(value) {
@@ -525,6 +559,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the default text color of an [EventChip].
      */
+    @PublicApi
     var defaultEventTextColor: Int
         get() = configWrapper.eventTextPaint.color
         set(value) {
@@ -535,6 +570,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the horizontal padding within an [EventChip].
      */
+    @PublicApi
     var eventPaddingHorizontal: Int
         get() = configWrapper.eventPaddingHorizontal
         set(value) {
@@ -545,6 +581,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the vertical padding within an [EventChip].
      */
+    @PublicApi
     var eventPaddingVertical: Int
         get() = configWrapper.eventPaddingVertical
         set(value) {
@@ -555,6 +592,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the default text color of an [EventChip].
      */
+    @PublicApi
     var defaultEventColor: Int
         get() = configWrapper.defaultEventColor
         set(value) {
@@ -573,6 +611,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the column gap at the end of each day.
      */
+    @PublicApi
     var columnGap: Int
         get() = configWrapper.columnGap
         set(value) {
@@ -583,6 +622,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the horizontal gap between overlapping [EventChip]s.
      */
+    @PublicApi
     var overlappingEventGap: Int
         get() = configWrapper.overlappingEventGap
         set(value) {
@@ -593,6 +633,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the vertical margin of an [EventChip].
      */
+    @PublicApi
     var eventMarginVertical: Int
         get() = configWrapper.eventMarginVertical
         set(value) {
@@ -604,6 +645,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns the horizontal margin of an [EventChip]. This margin is only applied in single-day
      * view and if there are no overlapping events.
      */
+    @PublicApi
     var eventMarginHorizontal: Int
         get() = configWrapper.eventMarginHorizontal
         set(value) {
@@ -622,6 +664,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the background color of a day.
      */
+    @PublicApi
     var dayBackgroundColor: Int
         get() = configWrapper.dayBackgroundPaint.color
         set(value) {
@@ -632,6 +675,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the background color of the current date.
      */
+    @PublicApi
     var todayBackgroundColor: Int
         get() = configWrapper.todayBackgroundPaint.color
         set(value) {
@@ -645,6 +689,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * The weekend background colors can be defined by [pastWeekendBackgroundColor] and
      * [futureWeekendBackgroundColor].
      */
+    @PublicApi
     var isShowDistinctWeekendColor: Boolean
         get() = configWrapper.showDistinctWeekendColor
         set(value) {
@@ -659,6 +704,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * The past and future day colors can be defined by [pastBackgroundColor] and
      * [futureBackgroundColor].
      */
+    @PublicApi
     var isShowDistinctPastFutureColor: Boolean
         get() = configWrapper.showDistinctPastFutureColor
         set(value) {
@@ -670,6 +716,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns the background color for past dates. If not explicitly set, WeekView will used
      * [dayBackgroundColor].
      */
+    @PublicApi
     var pastBackgroundColor: Int
         get() = configWrapper.pastBackgroundPaint.color
         set(value) {
@@ -681,6 +728,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns the background color for past weekend dates. If not explicitly set, WeekView will
      * used [pastBackgroundColor].
      */
+    @PublicApi
     var pastWeekendBackgroundColor: Int
         get() = configWrapper.pastWeekendBackgroundPaint.color
         set(value) {
@@ -692,6 +740,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns the background color for future dates. If not explicitly set, WeekView will used
      * [dayBackgroundColor].
      */
+    @PublicApi
     var futureBackgroundColor: Int
         get() = configWrapper.futureBackgroundPaint.color
         set(value) {
@@ -703,6 +752,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns the background color for future weekend dates. If not explicitly set, WeekView will
      * used [futureBackgroundColor].
      */
+    @PublicApi
     var futureWeekendBackgroundColor: Int
         get() = configWrapper.futureWeekendBackgroundPaint.color
         set(value) {
@@ -721,6 +771,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the current height of an hour.
      */
+    @PublicApi
     var hourHeight: Float
         get() = configWrapper.hourHeight
         set(value) {
@@ -731,6 +782,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the minimum height of an hour.
      */
+    @PublicApi
     var minHourHeight: Int
         get() = configWrapper.minHourHeight
         set(value) {
@@ -741,6 +793,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the maximum height of an hour.
      */
+    @PublicApi
     var maxHourHeight: Int
         get() = configWrapper.maxHourHeight
         set(value) {
@@ -752,6 +805,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns whether the complete day should be shown, in which case [hourHeight] automatically
      * adjusts to accommodate all hours between [minHour] and [maxHour].
      */
+    @PublicApi
     var isShowCompleteDay: Boolean
         get() = configWrapper.showCompleteDay
         set(value) {
@@ -770,6 +824,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns whether a horizontal line should be displayed at the current time.
      */
+    @PublicApi
     var isShowNowLine: Boolean
         get() = configWrapper.showNowLine
         set(value) {
@@ -780,6 +835,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the color of the horizontal "now" line.
      */
+    @PublicApi
     var nowLineColor: Int
         get() = configWrapper.nowLinePaint.color
         set(value) {
@@ -790,6 +846,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the stroke width of the horizontal "now" line.
      */
+    @PublicApi
     var nowLineStrokeWidth: Int
         get() = configWrapper.nowLinePaint.strokeWidth.toInt()
         set(value) {
@@ -801,6 +858,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns whether a dot at the start of the "now" line is displayed. The dot is only displayed
      * if [isShowNowLine] is set to true.
      */
+    @PublicApi
     var isShowNowLineDot: Boolean
         get() = configWrapper.showNowLineDot
         set(value) {
@@ -811,6 +869,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the color of the dot at the start of the "now" line.
      */
+    @PublicApi
     var nowLineDotColor: Int
         get() = configWrapper.nowDotPaint.color
         set(value) {
@@ -821,6 +880,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the radius of the dot at the start of the "now" line.
      */
+    @PublicApi
     var nowLineDotRadius: Int
         get() = configWrapper.nowDotPaint.strokeWidth.toInt()
         set(value) {
@@ -836,6 +896,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      ***********************************************************************************************
      */
 
+    @PublicApi
     var isShowHourSeparators: Boolean
         get() = configWrapper.showHourSeparators
         set(value) {
@@ -843,6 +904,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
             invalidate()
         }
 
+    @PublicApi
     var hourSeparatorColor: Int
         get() = configWrapper.hourSeparatorPaint.color
         set(value) {
@@ -850,6 +912,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
             invalidate()
         }
 
+    @PublicApi
     var hourSeparatorStrokeWidth: Int
         get() = configWrapper.hourSeparatorPaint.strokeWidth.toInt()
         set(value) {
@@ -868,6 +931,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns whether vertical lines are displayed as separators between dates.
      */
+    @PublicApi
     var isShowDaySeparators: Boolean
         get() = configWrapper.showDaySeparators
         set(value) {
@@ -878,6 +942,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the color of the separators between dates.
      */
+    @PublicApi
     var daySeparatorColor: Int
         get() = configWrapper.daySeparatorPaint.color
         set(value) {
@@ -888,6 +953,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the stroke color of the separators between dates.
      */
+    @PublicApi
     var daySeparatorStrokeWidth: Int
         get() = configWrapper.daySeparatorPaint.strokeWidth.toInt()
         set(value) {
@@ -907,6 +973,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns the minimum date that [WeekView] will display, or null if none is set. Events before
      * this date will not be shown.
      */
+    @PublicApi
     var minDate: Calendar?
         get() = configWrapper.minDate?.copy()
         set(value) {
@@ -923,6 +990,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns the maximum date that [WeekView] will display, or null if none is set. Events after
      * this date will not be shown.
      */
+    @PublicApi
     var maxDate: Calendar?
         get() = configWrapper.maxDate?.copy()
         set(value) {
@@ -947,6 +1015,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns the minimum hour that [WeekView] will display. Events before this time will not be
      * shown.
      */
+    @PublicApi
     var minHour: Int
         get() = configWrapper.minHour
         set(value) {
@@ -962,6 +1031,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Returns the maximum hour that [WeekView] will display. Events before this time will not be
      * shown.
      */
+    @PublicApi
     var maxHour: Int
         get() = configWrapper.maxHour
         set(value) {
@@ -984,6 +1054,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the scrolling speed factor in horizontal direction.
      */
+    @PublicApi
     var xScrollingSpeed: Float
         get() = configWrapper.xScrollingSpeed
         set(value) {
@@ -993,6 +1064,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns whether WeekView can fling horizontally.
      */
+    @PublicApi
     var isHorizontalFlingEnabled: Boolean
         get() = configWrapper.horizontalFlingEnabled
         set(value) {
@@ -1002,6 +1074,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns whether WeekView can scroll horizontally.
      */
+    @PublicApi
     var isHorizontalScrollingEnabled: Boolean
         get() = configWrapper.horizontalScrollingEnabled
         set(value) {
@@ -1011,12 +1084,14 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns whether WeekView can fling vertically.
      */
+    @PublicApi
     var isVerticalFlingEnabled: Boolean
         get() = configWrapper.verticalFlingEnabled
         set(value) {
             configWrapper.verticalFlingEnabled = value
         }
 
+    @PublicApi
     var scrollDuration: Int
         get() = configWrapper.scrollDuration
         set(value) {
@@ -1025,11 +1100,6 @@ class WeekView<T : Any> @JvmOverloads constructor(
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean = gestureHandler.onTouchEvent(event)
-
-    override fun computeScroll() {
-        super.computeScroll()
-        gestureHandler.computeScroll()
-    }
 
     /*
      ***********************************************************************************************
@@ -1042,18 +1112,21 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the first visible date.
      */
+    @PublicApi
     val firstVisibleDate: Calendar
         get() = viewState.firstVisibleDate.copy()
 
     /**
      * Returns the last visible date.
      */
+    @PublicApi
     val lastVisibleDate: Calendar
         get() = viewState.firstVisibleDate.copy() + Days(configWrapper.numberOfVisibleDays - 1)
 
     /**
      * Shows the current date.
      */
+    @PublicApi
     fun goToToday() {
         goToDate(today())
     }
@@ -1061,6 +1134,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Shows the current date and time.
      */
+    @PublicApi
     fun goToCurrentTime() {
         now().apply {
             goToDate(this)
@@ -1074,6 +1148,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      *
      * @param date The date to show.
      */
+    @PublicApi
     override fun goToDate(date: Calendar) {
         val adjustedDate = configWrapper.getDateWithinDateRange(date)
         gestureHandler.forceScrollFinished()
@@ -1096,6 +1171,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Refreshes the view and loads the events again.
      */
+    @PublicApi
     fun notifyDataSetChanged() {
         eventsLoader.requireRefresh()
         invalidate()
@@ -1109,6 +1185,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * @throws IllegalArgumentException Throws exception if the provided hour is smaller than
      *                                   [minHour] or larger than [maxHour].
      */
+    @PublicApi
     override fun goToHour(hour: Int) {
         if (viewState.areDimensionsInvalid) {
             viewState.scrollToHour = hour
@@ -1138,6 +1215,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the first hour that is visible on the screen.
      */
+    @PublicApi
     val firstVisibleHour: Double
         get() = (configWrapper.currentOrigin.y * -1 / configWrapper.hourHeight).toDouble()
 
@@ -1152,6 +1230,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
     /**
      * Returns the typeface used for events, time labels and date labels.
      */
+    @PublicApi
     var typeface: Typeface
         get() = configWrapper.typeface
         set(value) {
@@ -1167,12 +1246,14 @@ class WeekView<T : Any> @JvmOverloads constructor(
      ***********************************************************************************************
      */
 
+    @PublicApi
     var onEventClickListener: OnEventClickListener<T>?
-        get() = gestureHandler.onEventClickListener
+        get() = touchHandler.onEventClickListener
         set(value) {
-            gestureHandler.onEventClickListener = value
+            touchHandler.onEventClickListener = value
         }
 
+    @PublicApi
     fun setOnEventClickListener(
         block: (data: T, rect: RectF) -> Unit
     ) {
@@ -1183,6 +1264,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
         }
     }
 
+    @PublicApi
     var onMonthChangeListener: OnMonthChangeListener<T>?
         get() = (eventsLoader as? LegacyEventsLoader)?.onMonthChangeListener
         set(value) {
@@ -1190,6 +1272,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
             eventsLoaderWrapper.onListenerChanged(value)
         }
 
+    @PublicApi
     fun setOnMonthChangeListener(
         block: (startDate: Calendar, endDate: Calendar) -> List<WeekViewDisplayable<T>>
     ) {
@@ -1207,6 +1290,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Submits a list of [WeekViewDisplayable]s to [WeekView]. If the new events fall into the
      * currently displayed date range, this method will also redraw [WeekView].
      */
+    @PublicApi
     fun submit(items: List<WeekViewDisplayable<T>>) {
         eventsDiffer.submit(items) { shouldInvalidate ->
             if (shouldInvalidate) {
@@ -1215,6 +1299,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
         }
     }
 
+    @PublicApi
     var onLoadMoreListener: OnLoadMoreListener?
         get() = (eventsLoader as? PagedEventsLoader)?.onLoadMoreListener
         set(value) {
@@ -1226,6 +1311,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
      * Registers a block that is called whenever [WeekView] needs to load more events. This is
      * similar to an [OnMonthChangeListener], but does not require anything to be returned.
      */
+    @PublicApi
     fun setOnLoadMoreListener(
         block: (startDate: Calendar, endDate: Calendar) -> Unit
     ) {
@@ -1236,12 +1322,14 @@ class WeekView<T : Any> @JvmOverloads constructor(
         }
     }
 
+    @PublicApi
     var onEventLongClickListener: OnEventLongClickListener<T>?
-        get() = gestureHandler.onEventLongClickListener
+        get() = touchHandler.onEventLongClickListener
         set(value) {
-            gestureHandler.onEventLongClickListener = value
+            touchHandler.onEventLongClickListener = value
         }
 
+    @PublicApi
     fun setOnEventLongClickListener(
         block: (data: T, rect: RectF) -> Unit
     ) {
@@ -1252,12 +1340,14 @@ class WeekView<T : Any> @JvmOverloads constructor(
         }
     }
 
+    @PublicApi
     var onEmptyViewClickListener: OnEmptyViewClickListener?
-        get() = gestureHandler.onEmptyViewClickListener
+        get() = touchHandler.onEmptyViewClickListener
         set(value) {
-            gestureHandler.onEmptyViewClickListener = value
+            touchHandler.onEmptyViewClickListener = value
         }
 
+    @PublicApi
     fun setOnEmptyViewClickListener(
         block: (time: Calendar) -> Unit
     ) {
@@ -1268,12 +1358,14 @@ class WeekView<T : Any> @JvmOverloads constructor(
         }
     }
 
+    @PublicApi
     var onEmptyViewLongClickListener: OnEmptyViewLongClickListener?
-        get() = gestureHandler.onEmptyViewLongClickListener
+        get() = touchHandler.onEmptyViewLongClickListener
         set(value) {
-            gestureHandler.onEmptyViewLongClickListener = value
+            touchHandler.onEmptyViewLongClickListener = value
         }
 
+    @PublicApi
     fun setOnEmptyViewLongClickListener(
         block: (time: Calendar) -> Unit
     ) {
@@ -1284,24 +1376,28 @@ class WeekView<T : Any> @JvmOverloads constructor(
         }
     }
 
+    @PublicApi
     var scrollListener: ScrollListener?
         get() = gestureHandler.scrollListener
         set(value) {
             gestureHandler.scrollListener = value
         }
 
+    @PublicApi
     fun setScrollListener(
         block: (date: Calendar) -> Unit
     ) {
         scrollListener = object : ScrollListener {
             override fun onFirstVisibleDateChanged(date: Calendar) {
-                block(checkNotNull(firstVisibleDate))
+                block(firstVisibleDate)
             }
         }
     }
 
+    @PublicApi
     var onRangeChangeListener: OnRangeChangeListener? = null
 
+    @PublicApi
     fun setOnRangeChangeListener(
         block: (firstVisibleDate: Calendar, lastVisibleDate: Calendar) -> Unit
     ) {
@@ -1312,6 +1408,7 @@ class WeekView<T : Any> @JvmOverloads constructor(
         }
     }
 
+    @PublicApi
     var dateTimeInterpreter: DateTimeInterpreter
         get() = configWrapper.dateTimeInterpreter
         set(value) {

--- a/core/src/main/java/com/alamkanak/weekview/WeekViewAccessibilityTouchHelper.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekViewAccessibilityTouchHelper.kt
@@ -17,6 +17,7 @@ internal class WeekViewAccessibilityTouchHelper<T : Any>(
     private val config: WeekViewConfigWrapper,
     private val drawingContext: DrawingContext,
     private val gestureHandler: WeekViewGestureHandler<T>,
+    private val touchHandler: WeekViewTouchHandler<T>,
     private val eventChipCache: EventChipCache<T>
 ) : ExploreByTouchHelper(view) {
 
@@ -25,7 +26,6 @@ internal class WeekViewAccessibilityTouchHelper<T : Any>(
     private val dateFormatter = SimpleDateFormat.getDateInstance(LONG)
     private val dateTimeFormatter = SimpleDateFormat.getDateTimeInstance(LONG, SHORT)
 
-    private val touchHandler = WeekViewTouchHandler(config)
     private val store = VirtualViewIdStore<T>()
 
     override fun getVirtualViewAt(x: Float, y: Float): Int {
@@ -79,12 +79,12 @@ internal class WeekViewAccessibilityTouchHelper<T : Any>(
 
         return when (action) {
             AccessibilityNodeInfoCompat.ACTION_CLICK -> {
-                gestureHandler.onEventClickListener?.onEventClick(data, rect)
+                touchHandler.onEventClickListener?.onEventClick(data, rect)
                 sendEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED)
                 true
             }
             AccessibilityNodeInfoCompat.ACTION_LONG_CLICK -> {
-                gestureHandler.onEventLongClickListener?.onEventLongClick(data, rect)
+                touchHandler.onEventLongClickListener?.onEventLongClick(data, rect)
                 sendEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_LONG_CLICKED)
                 true
             }
@@ -99,12 +99,12 @@ internal class WeekViewAccessibilityTouchHelper<T : Any>(
     ): Boolean {
         return when (action) {
             AccessibilityNodeInfoCompat.ACTION_CLICK -> {
-                gestureHandler.onEmptyViewClickListener?.onEmptyViewClicked(date)
+                touchHandler.onEmptyViewClickListener?.onEmptyViewClicked(date)
                 sendEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_CLICKED)
                 true
             }
             AccessibilityNodeInfoCompat.ACTION_LONG_CLICK -> {
-                gestureHandler.onEmptyViewLongClickListener?.onEmptyViewLongClick(date)
+                touchHandler.onEmptyViewLongClickListener?.onEmptyViewLongClick(date)
                 sendEventForVirtualView(virtualViewId, AccessibilityEvent.TYPE_VIEW_LONG_CLICKED)
                 true
             }

--- a/core/src/main/java/com/alamkanak/weekview/WeekViewConfigWrapper.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekViewConfigWrapper.kt
@@ -51,8 +51,7 @@ internal class WeekViewConfigWrapper(
         color = config.todayHeaderTextColor
     }
 
-    var currentAllDayEventHeight: Int = 0
-        private set
+    private var currentAllDayEventHeight: Int = 0
 
     // Dates in the past have origin.x > 0, dates in the future have origin.x < 0
     var currentOrigin = PointF(0f, 0f)
@@ -517,7 +516,7 @@ internal class WeekViewConfigWrapper(
         widthPerDay = availableWidth / numberOfVisibleDays
     }
 
-    private fun getXOriginForDate(date: Calendar): Float {
+    fun getXOriginForDate(date: Calendar): Float {
         return -1f * date.daysFromToday * totalDayWidth
     }
 
@@ -534,7 +533,7 @@ internal class WeekViewConfigWrapper(
         val currentDayIsNotToday = today.dayOfWeek != firstDayOfWeek
 
         if (isWeekView && currentDayIsNotToday && showFirstDayOfWeekFirst) {
-            val difference = computeDifferenceWithFirstDayOfWeek(today)
+            val difference = today.computeDifferenceWithFirstDayOfWeek()
             currentOrigin.x += (widthPerDay + columnGap) * difference
         }
 
@@ -548,26 +547,22 @@ internal class WeekViewConfigWrapper(
     }
 
     private fun computeDifferenceWithCurrentTime(view: WeekView<*>) {
-        val now = now()
+        val desired = now()
 
-        val desired = if (now.hour > 0) {
+        if (desired.hour > minHour) {
             // Add some padding above the current time (and thus: the now line)
-            now - Hours(1)
-        } else {
-            now.atStartOfDay
+            desired -= Hours(1)
         }
 
-        val hour = desired.hour
-        val minutes = desired.minute
-        val fraction = minutes.toFloat() / Constants.MINUTES_PER_HOUR
+        val minTime = now().withTime(hour = minHour, minutes = 0)
+        val maxTime = now().withTime(hour = maxHour, minutes = 0)
+        desired.limitBy(minTime, maxTime)
 
-        var verticalOffset = hourHeight * (hour + fraction)
-        val viewHeight = view.height.toDouble()
+        val fraction = desired.minute.toFloat() / Constants.MINUTES_PER_HOUR
+        val verticalOffset = hourHeight * (desired.hour + fraction)
+        val desiredOffset = totalDayHeight - view.height
 
-        val desiredOffset = totalDayHeight - viewHeight
-        verticalOffset = min(desiredOffset.toFloat(), verticalOffset)
-
-        currentOrigin.y = verticalOffset * -1
+        currentOrigin.y = min(desiredOffset, verticalOffset) * -1
     }
 
     /**
@@ -583,23 +578,21 @@ internal class WeekViewConfigWrapper(
         } else if (date.isAfter(maxDate)) {
             maxDate + Days(1 - numberOfVisibleDays)
         } else if (numberOfVisibleDays >= 7 && showFirstDayOfWeekFirst) {
-            val diff = computeDifferenceWithFirstDayOfWeek(date)
+            val diff = date.computeDifferenceWithFirstDayOfWeek()
             date - Days(diff)
         } else {
             date
         }
     }
 
-    private fun computeDifferenceWithFirstDayOfWeek(
-        date: Calendar
-    ): Int {
+    private fun Calendar.computeDifferenceWithFirstDayOfWeek(): Int {
         val firstDayOfWeek = firstDayOfWeek
-        return if (firstDayOfWeek == Calendar.MONDAY && date.dayOfWeek == Calendar.SUNDAY) {
+        return if (firstDayOfWeek == Calendar.MONDAY && dayOfWeek == Calendar.SUNDAY) {
             // Special case, because Calendar.MONDAY has constant value 2 and Calendar.SUNDAY has
             // constant value 1. The correct result to return is 6 days, not -1 days.
             6
         } else {
-            date.dayOfWeek - firstDayOfWeek
+            dayOfWeek - firstDayOfWeek
         }
     }
 

--- a/core/src/main/java/com/alamkanak/weekview/WeekViewConfigWrapper.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekViewConfigWrapper.kt
@@ -251,9 +251,6 @@ internal class WeekViewConfigWrapper(
             config.maxHour = value
         }
 
-    val timeRange: IntRange
-        get() = minHour..maxHour
-
     var xScrollingSpeed: Float
         get() = config.xScrollingSpeed
         set(value) {
@@ -438,8 +435,13 @@ internal class WeekViewConfigWrapper(
     val minutesPerDay: Int
         get() = (hoursPerDay * Constants.MINUTES_PER_HOUR).toInt()
 
-    val startHour: Int
-        get() = if (showMidnightHour && showTimeColumnHourSeparator) minHour else timeColumnHoursInterval
+    val timeRange: IntRange
+        get() {
+            val includeMidnightHour = showTimeColumnHourSeparator && showMidnightHour
+            val padding = if (includeMidnightHour) 0 else timeColumnHoursInterval
+            val startHour = minHour + padding
+            return startHour until maxHour
+        }
 
     var eventCornerRadius: Int
         get() = config.eventCornerRadius
@@ -538,7 +540,7 @@ internal class WeekViewConfigWrapper(
         }
 
         if (showCurrentTimeFirst) {
-            computeDifferenceWithCurrentTime(view)
+            scrollToCurrentTime(view)
         }
 
         // Overwrites the origin when today is out of date range
@@ -546,9 +548,8 @@ internal class WeekViewConfigWrapper(
         currentOrigin.x = max(currentOrigin.x, minX)
     }
 
-    private fun computeDifferenceWithCurrentTime(view: WeekView<*>) {
+    private fun scrollToCurrentTime(view: WeekView<*>) {
         val desired = now()
-
         if (desired.hour > minHour) {
             // Add some padding above the current time (and thus: the now line)
             desired -= Hours(1)

--- a/core/src/main/java/com/alamkanak/weekview/WeekViewEvent.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekViewEvent.kt
@@ -19,7 +19,7 @@ data class WeekViewEvent<T> internal constructor(
     internal val locationResource: TextResource? = null,
     val isAllDay: Boolean = false,
     val style: Style = Style(),
-    val data: T? = null
+    val data: T
 ) : WeekViewDisplayable<T>, Comparable<WeekViewEvent<T>> {
 
     internal val isNotAllDay: Boolean
@@ -145,51 +145,61 @@ data class WeekViewEvent<T> internal constructor(
 
             private val style = Style()
 
+            @PublicApi
             fun setBackgroundColor(@ColorInt color: Int): Builder {
                 style.backgroundColorResource = ColorResource.Value(color)
                 return this
             }
 
+            @PublicApi
             fun setBackgroundColorResource(@ColorRes resId: Int): Builder {
                 style.backgroundColorResource = ColorResource.Id(resId)
                 return this
             }
 
+            @PublicApi
             fun setTextColor(@ColorInt color: Int): Builder {
                 style.textColorResource = ColorResource.Value(color)
                 return this
             }
 
+            @PublicApi
             fun setTextColorResource(@ColorRes resId: Int): Builder {
                 style.textColorResource = ColorResource.Id(resId)
                 return this
             }
 
+            @PublicApi
             fun setTextStrikeThrough(strikeThrough: Boolean): Builder {
                 style.isTextStrikeThrough = strikeThrough
                 return this
             }
 
+            @PublicApi
             fun setBorderWidth(width: Int): Builder {
                 style.borderWidthResource = DimenResource.Value(width)
                 return this
             }
 
+            @PublicApi
             fun setBorderWidthResource(@DimenRes resId: Int): Builder {
                 style.borderWidthResource = DimenResource.Id(resId)
                 return this
             }
 
+            @PublicApi
             fun setBorderColor(@ColorInt color: Int): Builder {
                 style.borderColorResource = ColorResource.Value(color)
                 return this
             }
 
+            @PublicApi
             fun setBorderColorResource(@ColorRes resId: Int): Builder {
                 style.borderColorResource = ColorResource.Id(resId)
                 return this
             }
 
+            @PublicApi
             fun build(): Style = style
         }
     }
@@ -206,51 +216,61 @@ data class WeekViewEvent<T> internal constructor(
         private var style: Style? = null
         private var isAllDay: Boolean = false
 
+        @PublicApi
         fun setId(id: Long): Builder<T> {
             this.id = id
             return this
         }
 
+        @PublicApi
         fun setTitle(title: CharSequence): Builder<T> {
             this.title = TextResource.Value(title)
             return this
         }
 
+        @PublicApi
         fun setTitle(resId: Int): Builder<T> {
             this.title = TextResource.Id(resId)
             return this
         }
 
+        @PublicApi
         fun setStartTime(startTime: Calendar): Builder<T> {
             this.startTime = startTime
             return this
         }
 
+        @PublicApi
         fun setEndTime(endTime: Calendar): Builder<T> {
             this.endTime = endTime
             return this
         }
 
+        @PublicApi
         fun setLocation(location: CharSequence): Builder<T> {
             this.location = TextResource.Value(location)
             return this
         }
 
+        @PublicApi
         fun setLocation(resId: Int): Builder<T> {
             this.location = TextResource.Id(resId)
             return this
         }
 
+        @PublicApi
         fun setStyle(style: Style): Builder<T> {
             this.style = style
             return this
         }
 
+        @PublicApi
         fun setAllDay(isAllDay: Boolean): Builder<T> {
             this.isAllDay = isAllDay
             return this
         }
 
+        @PublicApi
         fun build(): WeekViewEvent<T> {
             val id = checkNotNull(id) { "id == null" }
             val title = checkNotNull(title) { "title == null" }

--- a/core/src/main/java/com/alamkanak/weekview/WeekViewViewState.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekViewViewState.kt
@@ -14,8 +14,7 @@ internal class WeekViewViewState(
     private var isFirstDraw = true
     var areDimensionsInvalid = true
 
-    var firstVisibleDate: Calendar? = null
-    var lastVisibleDate: Calendar? = null
+    var firstVisibleDate: Calendar = today()
 
     fun update(viewHeight: Int) {
         val totalHeaderHeight = config.getTotalHeaderHeight().toInt()

--- a/jodatime/src/main/java/com/alamkanak/weekview/jodatime/WeekViewAdapter.kt
+++ b/jodatime/src/main/java/com/alamkanak/weekview/jodatime/WeekViewAdapter.kt
@@ -33,9 +33,9 @@ class WeekViewAdapter<T : Any>(
             weekView.maxDate = value?.toCalendar()
         }
 
-    val firstVisibleDate: LocalDate?
-        get() = weekView.firstVisibleDate?.toLocalDate()
+    val firstVisibleDate: LocalDate
+        get() = weekView.firstVisibleDate.toLocalDate()
 
-    val lastVisibleDate: LocalDate?
-        get() = weekView.lastVisibleDate?.toLocalDate()
+    val lastVisibleDate: LocalDate
+        get() = weekView.lastVisibleDate.toLocalDate()
 }

--- a/jsr310/src/main/java/com/alamkanak/weekview/jsr310/WeekViewAdapter.kt
+++ b/jsr310/src/main/java/com/alamkanak/weekview/jsr310/WeekViewAdapter.kt
@@ -33,9 +33,9 @@ class WeekViewAdapter<T : Any>(
             weekView.maxDate = value?.toCalendar()
         }
 
-    val firstVisibleDate: LocalDate?
-        get() = weekView.firstVisibleDate?.toLocalDate()
+    val firstVisibleDate: LocalDate
+        get() = weekView.firstVisibleDate.toLocalDate()
 
-    val lastVisibleDate: LocalDate?
-        get() = weekView.lastVisibleDate?.toLocalDate()
+    val lastVisibleDate: LocalDate
+        get() = weekView.lastVisibleDate.toLocalDate()
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -14,6 +14,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
+    }
 }
 
 dependencies {

--- a/sample/src/main/java/com/alamkanak/weekview/sample/StaticActivity.kt
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/StaticActivity.kt
@@ -4,7 +4,6 @@ import android.graphics.RectF
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.util.Preconditions.checkNotNull
 import com.alamkanak.weekview.OnEmptyViewLongClickListener
 import com.alamkanak.weekview.OnEventClickListener
 import com.alamkanak.weekview.OnEventLongClickListener
@@ -44,13 +43,13 @@ class StaticActivity : AppCompatActivity(), OnEventClickListener<Event>,
         weekView.onEmptyViewLongClickListener = this
 
         previousWeekButton.setOnClickListener {
-            val cal = checkNotNull(weekView.firstVisibleDate)
+            val cal = weekView.firstVisibleDate
             cal.add(Calendar.DATE, -7)
             weekView.goToDate(cal)
         }
 
         nextWeekButton.setOnClickListener {
-            val cal = checkNotNull(weekView.firstVisibleDate)
+            val cal = weekView.firstVisibleDate
             cal.add(Calendar.DATE, 7)
             weekView.goToDate(cal)
         }
@@ -68,13 +67,13 @@ class StaticActivity : AppCompatActivity(), OnEventClickListener<Event>,
         endDate: Calendar
     ) = database.getEventsInRange(startDate, endDate)
 
-    override fun onEventClick(event: Event, eventRect: RectF) {
-        showToast("Clicked ${event.title}")
+    override fun onEventClick(data: Event, eventRect: RectF) {
+        showToast("Clicked ${data.title}")
     }
 
-    override fun onEventLongClick(event: Event, eventRect: RectF) {
-        showToast("Long-clicked ${event.title}")
-        Toast.makeText(this, "Long pressed event: " + event.title, Toast.LENGTH_SHORT).show()
+    override fun onEventLongClick(data: Event, eventRect: RectF) {
+        showToast("Long-clicked ${data.title}")
+        Toast.makeText(this, "Long pressed event: " + data.title, Toast.LENGTH_SHORT).show()
     }
 
     override fun onEmptyViewLongClick(time: Calendar) {

--- a/threetenabp/src/main/java/com/alamkanak/weekview/threetenabp/WeekViewAdapter.kt
+++ b/threetenabp/src/main/java/com/alamkanak/weekview/threetenabp/WeekViewAdapter.kt
@@ -33,9 +33,9 @@ class WeekViewAdapter<T : Any>(
             weekView.maxDate = value?.toCalendar()
         }
 
-    val firstVisibleDate: LocalDate?
-        get() = weekView.firstVisibleDate?.toLocalDate()
+    val firstVisibleDate: LocalDate
+        get() = weekView.firstVisibleDate.toLocalDate()
 
-    val lastVisibleDate: LocalDate?
-        get() = weekView.lastVisibleDate?.toLocalDate()
+    val lastVisibleDate: LocalDate
+        get() = weekView.lastVisibleDate.toLocalDate()
 }


### PR DESCRIPTION
This pull request adds improved scrolling to WeekView. Instead of using the existing `OverScroller` which would scroll on forever, WeekView now uses a custom scroller that only scrolls as many days as are visible right now. This brings it in line with calendar apps such as Google Calendar.

This also resolves #4.