### PR TITLE
Show all-day events with full day width

### DIFF
--- a/core/src/main/java/com/alamkanak/weekview/EventChip.kt
+++ b/core/src/main/java/com/alamkanak/weekview/EventChip.kt
@@ -54,6 +54,12 @@ internal data class EventChip(
      */
     var relativeWidth: Float = 0f
 
+    /**
+     * Returns whether the [EventChip] of an all-day event is currently hidden, if all-day events
+     * are arranged vertically.
+     */
+    var isHidden: Boolean = false
+
     var minutesFromStartHour: Int = 0
 
     fun setEmpty() {

--- a/core/src/main/java/com/alamkanak/weekview/EventChipBoundsCalculator.kt
+++ b/core/src/main/java/com/alamkanak/weekview/EventChipBoundsCalculator.kt
@@ -51,19 +51,47 @@ internal class EventChipBoundsCalculator(
         startPixel: Float
     ): RectF {
         val padding = viewState.headerPadding
+        val dayWidth = viewState.drawableDayWidth
+
         val dateLabelHeight = padding + viewState.dateLabelHeight + padding
-
         val chipHeight = viewState.allDayEventTextPaint.textSize + viewState.eventPaddingVertical * 2
-        val previousChipsHeight = index * (eventChip.bounds.height() + viewState.eventMarginVertical)
 
-        val top = dateLabelHeight + previousChipsHeight
-        var right = startPixel + viewState.drawableDayWidth
+        val top = if (viewState.arrangeAllDayEventsVertically) {
+            val previousChipsHeight = index * (eventChip.bounds.height() + viewState.eventMarginVertical)
+            dateLabelHeight + previousChipsHeight
+        } else {
+            dateLabelHeight
+        }
+
+        var left = if (viewState.arrangeAllDayEventsVertically) {
+            startPixel
+        } else {
+            startPixel + eventChip.relativeStart * dayWidth
+        }
+
+        var right = if (viewState.arrangeAllDayEventsVertically) {
+            left + dayWidth
+        } else {
+            left + eventChip.relativeWidth * dayWidth
+        }
+
+        val isLeftMostColumn = left == startPixel
+        val isRightMostColumn = right == startPixel + dayWidth
+
+        if (!isLeftMostColumn) {
+            left += viewState.overlappingEventGap / 2f
+        }
+
+        if (!isRightMostColumn) {
+            right -= viewState.overlappingEventGap / 2f
+        }
+
         val bottom = top + chipHeight
 
-        if (viewState.isSingleDay) {
+        if (viewState.isSingleDay && isRightMostColumn) {
             right -= viewState.singleDayHorizontalPadding * 2
         }
 
-        return RectF(startPixel, top, right, bottom)
+        return RectF(left, top, right, bottom)
     }
 }

--- a/core/src/main/java/com/alamkanak/weekview/EventChipBoundsCalculator.kt
+++ b/core/src/main/java/com/alamkanak/weekview/EventChipBoundsCalculator.kt
@@ -46,33 +46,24 @@ internal class EventChipBoundsCalculator(
     }
 
     fun calculateAllDayEvent(
+        index: Int,
         eventChip: EventChip,
         startPixel: Float
     ): RectF {
         val padding = viewState.headerPadding
+        val dateLabelHeight = padding + viewState.dateLabelHeight + padding
 
-        val top = padding + viewState.dateLabelHeight + padding
-        val height = viewState.allDayEventTextPaint.textSize + viewState.eventPaddingVertical * 2
-        val bottom = top + height
+        val chipHeight = viewState.allDayEventTextPaint.textSize + viewState.eventPaddingVertical * 2
+        val previousChipsHeight = index * (eventChip.bounds.height() + viewState.eventMarginVertical)
 
-        val chipWidth = viewState.drawableDayWidth
+        val top = dateLabelHeight + previousChipsHeight
+        var right = startPixel + viewState.drawableDayWidth
+        val bottom = top + chipHeight
 
-        var left = startPixel + eventChip.relativeStart * chipWidth
-        var right = left + eventChip.relativeWidth * chipWidth
-
-        if (left > startPixel) {
-            left += viewState.overlappingEventGap / 2f
-        }
-
-        if (right < startPixel + chipWidth) {
-            right -= viewState.overlappingEventGap / 2f
-        }
-
-        val hasNoOverlaps = (right == startPixel + chipWidth)
-        if (viewState.isSingleDay && hasNoOverlaps) {
+        if (viewState.isSingleDay) {
             right -= viewState.singleDayHorizontalPadding * 2
         }
 
-        return RectF(left, top, right, bottom)
+        return RectF(startPixel, top, right, bottom)
     }
 }

--- a/core/src/main/java/com/alamkanak/weekview/EventChipsFactory.kt
+++ b/core/src/main/java/com/alamkanak/weekview/EventChipsFactory.kt
@@ -38,7 +38,7 @@ internal class EventChipsFactory {
         for (eventChip in eventChips) {
             val collidingGroup = collisionGroups.firstOrNull { it.collidesWith(eventChip) }
 
-            if (collidingGroup != null) {
+            if (collidingGroup != null && eventChip.originalEvent.isNotAllDay) {
                 collidingGroup.add(eventChip)
             } else {
                 collisionGroups += CollisionGroup(eventChip)

--- a/core/src/main/java/com/alamkanak/weekview/EventChipsFactory.kt
+++ b/core/src/main/java/com/alamkanak/weekview/EventChipsFactory.kt
@@ -33,21 +33,43 @@ internal class EventChipsFactory {
      * @param eventChips A list of [EventChip]s
      */
     private fun computePositionOfEvents(eventChips: List<EventChip>, viewState: ViewState) {
+        val singleEventChips = eventChips.filter { it.event.isNotAllDay }
+        val allDayEventChips = eventChips.filter { it.event.isAllDay }
+
+        val singleEventGroups = singleEventChips.toMultiColumnCollisionGroups()
+        val allDayGroups = if (viewState.arrangeAllDayEventsVertically) {
+            allDayEventChips.toSingleColumnCollisionGroups()
+        } else {
+            allDayEventChips.toMultiColumnCollisionGroups()
+        }
+
+        for (collisionGroup in singleEventGroups) {
+            expandEventsToMaxWidth(collisionGroup, viewState)
+        }
+
+        for (collisionGroup in allDayGroups) {
+            expandEventsToMaxWidth(collisionGroup, viewState)
+        }
+    }
+
+    private fun List<EventChip>.toSingleColumnCollisionGroups(): List<CollisionGroup> {
+        return map { CollisionGroup(it) }
+    }
+
+    private fun List<EventChip>.toMultiColumnCollisionGroups(): List<CollisionGroup> {
         val collisionGroups = mutableListOf<CollisionGroup>()
 
-        for (eventChip in eventChips) {
+        for (eventChip in this) {
             val collidingGroup = collisionGroups.firstOrNull { it.collidesWith(eventChip) }
 
-            if (collidingGroup != null && eventChip.originalEvent.isNotAllDay) {
+            if (collidingGroup != null) {
                 collidingGroup.add(eventChip)
             } else {
                 collisionGroups += CollisionGroup(eventChip)
             }
         }
 
-        for (collisionGroup in collisionGroups) {
-            expandEventsToMaxWidth(collisionGroup, viewState)
-        }
+        return collisionGroups
     }
 
     /**
@@ -76,14 +98,14 @@ internal class EventChipsFactory {
                             column.add(eventChip)
                         }
                     } else {
-                        val leftMostColumn = checkNotNull(fittingColumns.minBy { it.index })
+                        val leftMostColumn = checkNotNull(fittingColumns.minByOrNull { it.index })
                         leftMostColumn.add(eventChip)
                     }
                 }
             }
         }
 
-        val rows = columns.map { it.size }.max() ?: 0
+        val rows = columns.map { it.size }.maxOrNull() ?: 0
         val columnWidth = 1f / columns.size
 
         for (row in 0 until rows) {

--- a/core/src/main/java/com/alamkanak/weekview/HeaderRenderer.kt
+++ b/core/src/main/java/com/alamkanak/weekview/HeaderRenderer.kt
@@ -188,8 +188,9 @@ private class AllDayEventsUpdater(
             }
 
             val eventChips = eventChipsCache.allDayEventChipsByDate(date)
-            for (eventChip in eventChips) {
-                eventChip.updateBounds(startPixel = modifiedStartPixel)
+
+            eventChips.forEachIndexed { index, eventChip ->
+                eventChip.updateBounds(index = index, startPixel = modifiedStartPixel)
                 if (eventChip.bounds.isNotEmpty) {
                     eventsLabelLayouts[eventChip] = textFitter.fit(eventChip)
                 } else {
@@ -203,10 +204,17 @@ private class AllDayEventsUpdater(
             .maxOrNull() ?: 0
 
         viewState.currentAllDayEventHeight = maximumChipHeight
+
+        val maximumChipsPerDay = eventsLabelLayouts.keys
+            .groupBy { it.event.startTime.toEpochDays() }
+            .values
+            .maxByOrNull { it.size }?.size ?: 0
+
+        viewState.maxNumberOfAllDayEvents = maximumChipsPerDay
     }
 
-    private fun EventChip.updateBounds(startPixel: Float) {
-        val candidate = boundsCalculator.calculateAllDayEvent(this, startPixel)
+    private fun EventChip.updateBounds(index: Int, startPixel: Float) {
+        val candidate = boundsCalculator.calculateAllDayEvent(index, eventChip = this, startPixel)
         bounds = if (candidate.isValid) candidate else RectF()
     }
 

--- a/core/src/main/java/com/alamkanak/weekview/HeaderRenderer.kt
+++ b/core/src/main/java/com/alamkanak/weekview/HeaderRenderer.kt
@@ -262,6 +262,10 @@ internal class AllDayEventsDrawer(
     }
 
     private fun Canvas.renderEventsVertically(events: List<Pair<EventChip, StaticLayout>>) {
+        // Un-hide all events. To prevent any click handler from mapping a click to a hidden event,
+        // we set isHidden to true for all events that aren't shown in the collapsed state.
+        events.forEach { it.first.isHidden = false }
+
         if (viewState.allDayEventsExpanded || events.size <= 2) {
             // Draw them all!
             for ((eventChip, textLayout) in events) {
@@ -274,9 +278,11 @@ internal class AllDayEventsDrawer(
             val needsExpandInfo = events.size >= 2
             if (needsExpandInfo) {
                 drawExpandInfo(eventsCount = events.size - 1, priorEventChip = firstEventChip)
+                events.drop(1).forEach { it.first.isHidden = true }
             } else {
-                val (secondEventChip, secondTextLayout) = events[0]
+                val (secondEventChip, secondTextLayout) = events[1]
                 eventChipDrawer.draw(secondEventChip, canvas = this, secondTextLayout)
+                events.drop(2).forEach { it.first.isHidden = true }
             }
         }
     }

--- a/core/src/main/java/com/alamkanak/weekview/ViewState.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ViewState.kt
@@ -116,6 +116,8 @@ internal class ViewState {
 
     var currentAllDayEventHeight: Int = 0
 
+    var maxNumberOfAllDayEvents: Int = 0
+
     // Dates in the past have origin.x > 0, dates in the future have origin.x < 0
     var currentOrigin = PointF(0f, 0f)
 
@@ -370,8 +372,13 @@ internal class ViewState {
     fun calculateHeaderHeight(): Float {
         var newHeight = headerPadding + dateLabelHeight + headerPadding
 
-        if (currentAllDayEventHeight > 0) {
-            newHeight += currentAllDayEventHeight.toFloat() + headerPadding
+        if (maxNumberOfAllDayEvents > 0) {
+            val heightOfChips = maxNumberOfAllDayEvents * currentAllDayEventHeight
+            val heightOfSpacing = (maxNumberOfAllDayEvents - 1) * eventMarginVertical
+            newHeight += heightOfChips + heightOfSpacing
+
+            // Add padding below the event chips
+            newHeight += headerPadding
         }
 
         if (showHeaderBottomLine) {

--- a/core/src/main/java/com/alamkanak/weekview/ViewState.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ViewState.kt
@@ -37,6 +37,7 @@ internal class ViewState {
     var restoreNumberOfVisibleDays: Boolean = true
     var showFirstDayOfWeekFirst: Boolean = false
     var showCurrentTimeFirst: Boolean = false
+    var arrangeAllDayEventsVertically: Boolean = true
 
     // Time column
     var timeColumnPadding: Int = 0
@@ -121,7 +122,7 @@ internal class ViewState {
     var allDayEventsExpanded: Boolean = false
 
     val showAllDayEventsToggleArrow: Boolean
-        get() = maxNumberOfAllDayEvents > 2
+        get() = arrangeAllDayEventsVertically && maxNumberOfAllDayEvents > 2
 
     // Dates in the past have origin.x > 0, dates in the future have origin.x < 0
     var currentOrigin = PointF(0f, 0f)
@@ -388,10 +389,12 @@ internal class ViewState {
         var newHeight = headerPadding + dateLabelHeight + headerPadding
 
         if (maxNumberOfAllDayEvents > 0) {
-            val numberOfRows = if (allDayEventsExpanded) {
+            val numberOfRows = if (arrangeAllDayEventsVertically && allDayEventsExpanded) {
                 maxNumberOfAllDayEvents
-            } else {
+            } else if (arrangeAllDayEventsVertically) {
                 min(maxNumberOfAllDayEvents, 2)
+            } else {
+                1
             }
 
             val heightOfChips = numberOfRows * currentAllDayEventHeight

--- a/core/src/main/java/com/alamkanak/weekview/ViewState.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ViewState.kt
@@ -118,6 +118,11 @@ internal class ViewState {
 
     var maxNumberOfAllDayEvents: Int = 0
 
+    var allDayEventsExpanded: Boolean = false
+
+    val showAllDayEventsToggleArrow: Boolean
+        get() = maxNumberOfAllDayEvents > 2
+
     // Dates in the past have origin.x > 0, dates in the future have origin.x < 0
     var currentOrigin = PointF(0f, 0f)
 
@@ -226,6 +231,16 @@ internal class ViewState {
         get() = _weekNumberBounds.apply {
             left = 0f
             top = 0f
+            right = timeColumnWidth
+            bottom = headerPadding + dateLabelHeight + headerPadding
+        }
+
+    private val _toggleAllDayEventsAreaBounds: RectF = RectF()
+
+    val toggleAllDayEventsAreaBounds: RectF
+        get() = _toggleAllDayEventsAreaBounds.apply {
+            left = 0f
+            top = weekNumberBounds.bottom
             right = timeColumnWidth
             bottom = headerHeight
         }
@@ -373,8 +388,14 @@ internal class ViewState {
         var newHeight = headerPadding + dateLabelHeight + headerPadding
 
         if (maxNumberOfAllDayEvents > 0) {
-            val heightOfChips = maxNumberOfAllDayEvents * currentAllDayEventHeight
-            val heightOfSpacing = (maxNumberOfAllDayEvents - 1) * eventMarginVertical
+            val numberOfRows = if (allDayEventsExpanded) {
+                maxNumberOfAllDayEvents
+            } else {
+                min(maxNumberOfAllDayEvents, 2)
+            }
+
+            val heightOfChips = numberOfRows * currentAllDayEventHeight
+            val heightOfSpacing = (numberOfRows - 1) * eventMarginVertical
             newHeight += heightOfChips + heightOfSpacing
 
             // Add padding below the event chips

--- a/core/src/main/java/com/alamkanak/weekview/ViewStateFactory.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ViewStateFactory.kt
@@ -143,6 +143,7 @@ internal object ViewStateFactory {
             restoreNumberOfVisibleDays = a.getBoolean(R.styleable.WeekView_restoreNumberOfVisibleDays, true)
             showFirstDayOfWeekFirst = a.getBoolean(R.styleable.WeekView_showFirstDayOfWeekFirst, false)
             showCurrentTimeFirst = a.getBoolean(R.styleable.WeekView_showCurrentTimeFirst, false)
+            arrangeAllDayEventsVertically = a.getBoolean(R.styleable.WeekView_arrangeAllDayEventsVertically, true)
         }
 
         viewState.apply {

--- a/core/src/main/java/com/alamkanak/weekview/ViewStateFactory.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ViewStateFactory.kt
@@ -37,7 +37,7 @@ internal object ViewStateFactory {
 
         viewState.headerBottomLinePaint.apply {
             color = a.getColor(R.styleable.WeekView_headerBottomLineColor, context.lineColor)
-            strokeWidth = a.getDimension(R.styleable.WeekView_headerBottomLineWidth, 1f)
+            strokeWidth = a.getDimension(R.styleable.WeekView_headerBottomLineWidth, context.dp(1))
         }
 
         viewState.todayHeaderTextPaint.apply {
@@ -59,18 +59,18 @@ internal object ViewStateFactory {
         viewState.headerBackgroundWithShadowPaint.apply {
             color = viewState.headerBackgroundPaint.color
             val shadowColor = a.getColor(R.styleable.WeekView_headerBottomShadowColor, context.shadowColor)
-            val shadowRadius = a.getDimension(R.styleable.WeekView_headerBottomShadowRadius, 4f)
+            val shadowRadius = a.getDimension(R.styleable.WeekView_headerBottomShadowRadius, context.dp(2))
             setShadowLayer(shadowRadius, 0f, 0f, shadowColor)
         }
 
         viewState.hourSeparatorPaint.apply {
             color = a.getColor(R.styleable.WeekView_hourSeparatorColor, context.lineColor)
-            strokeWidth = a.getDimension(R.styleable.WeekView_hourSeparatorStrokeWidth, 2f)
+            strokeWidth = a.getDimension(R.styleable.WeekView_hourSeparatorStrokeWidth, context.dp(1))
         }
 
         viewState.daySeparatorPaint.apply {
             color = a.getColor(R.styleable.WeekView_daySeparatorColor, context.lineColor)
-            strokeWidth = a.getDimension(R.styleable.WeekView_daySeparatorStrokeWidth, 2f)
+            strokeWidth = a.getDimension(R.styleable.WeekView_daySeparatorStrokeWidth, context.dp(1))
         }
 
         viewState.dayBackgroundPaint.apply {
@@ -99,17 +99,17 @@ internal object ViewStateFactory {
 
         viewState.timeColumnSeparatorPaint.apply {
             color = a.getColor(R.styleable.WeekView_timeColumnSeparatorColor, context.lineColor)
-            strokeWidth = a.getDimension(R.styleable.WeekView_timeColumnSeparatorStrokeWidth, 1f)
+            strokeWidth = a.getDimension(R.styleable.WeekView_timeColumnSeparatorStrokeWidth, context.dp(1))
         }
 
         viewState.nowLinePaint.apply {
             color = a.getColor(R.styleable.WeekView_nowLineColor, context.colorAccent)
-            strokeWidth = a.getDimension(R.styleable.WeekView_nowLineStrokeWidth, 5f)
+            strokeWidth = a.getDimension(R.styleable.WeekView_nowLineStrokeWidth, context.dp(3))
         }
 
         viewState.nowDotPaint.apply {
             color = a.getColor(R.styleable.WeekView_nowLineDotColor, context.colorAccent)
-            strokeWidth = a.getDimension(R.styleable.WeekView_nowLineDotRadius, 16f)
+            strokeWidth = a.getDimension(R.styleable.WeekView_nowLineDotRadius, context.dp(4))
         }
 
         viewState.eventTextPaint.apply {
@@ -166,26 +166,26 @@ internal object ViewStateFactory {
         }
 
         viewState.apply {
-            headerPadding = a.getDimension(R.styleable.WeekView_headerPadding, 10f)
+            headerPadding = a.getDimension(R.styleable.WeekView_headerPadding, context.dp(8))
         }
 
         viewState.apply {
             showWeekNumber = a.getBoolean(R.styleable.WeekView_showWeekNumber, false)
-            weekNumberBackgroundCornerRadius = a.getDimension(R.styleable.WeekView_weekNumberBackgroundCornerRadius, 0f)
+            weekNumberBackgroundCornerRadius = a.getDimension(R.styleable.WeekView_weekNumberBackgroundCornerRadius, context.dp(8))
         }
 
         viewState.apply {
-            eventCornerRadius = a.getDimensionPixelSize(R.styleable.WeekView_eventCornerRadius, 0)
+            eventCornerRadius = a.getDimensionPixelSize(R.styleable.WeekView_eventCornerRadius, context.dp(2).roundToInt())
             adaptiveEventTextSize = a.getBoolean(R.styleable.WeekView_adaptiveEventTextSize, false)
             defaultEventColor = a.getColor(R.styleable.WeekView_defaultEventColor, context.colorAccent)
         }
 
         viewState.apply {
-            eventPaddingHorizontal = a.getDimensionPixelSize(R.styleable.WeekView_eventPaddingHorizontal, 8)
-            eventPaddingVertical = a.getDimensionPixelSize(R.styleable.WeekView_eventPaddingVertical, 8)
-            columnGap = a.getDimensionPixelSize(R.styleable.WeekView_columnGap, 10)
+            eventPaddingHorizontal = a.getDimensionPixelSize(R.styleable.WeekView_eventPaddingHorizontal, context.dp(4).roundToInt())
+            eventPaddingVertical = a.getDimensionPixelSize(R.styleable.WeekView_eventPaddingVertical, context.dp(4).roundToInt())
+            columnGap = a.getDimensionPixelSize(R.styleable.WeekView_columnGap, context.dp(8).roundToInt())
             overlappingEventGap = a.getDimensionPixelSize(R.styleable.WeekView_overlappingEventGap, 0)
-            eventMarginVertical = a.getDimensionPixelSize(R.styleable.WeekView_eventMarginVertical, 2)
+            eventMarginVertical = a.getDimensionPixelSize(R.styleable.WeekView_eventMarginVertical, context.dp(2).roundToInt())
             singleDayHorizontalPadding = a.getDimensionPixelSize(R.styleable.WeekView_singleDayHorizontalPadding, 0)
         }
 
@@ -277,4 +277,12 @@ private val Context.windowBackground: Int
     get() = resolveColor(android.R.attr.windowBackground)
 
 private val Context.defaultTextSize: Float
-    get() = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 12f, resources.displayMetrics)
+    get() = sp(12)
+
+private fun Context.dp(value: Int): Float {
+    return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value.toFloat(), resources.displayMetrics)
+}
+
+private fun Context.sp(value: Int): Float {
+    return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, value.toFloat(), resources.displayMetrics)
+}

--- a/core/src/main/java/com/alamkanak/weekview/WeekView.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekView.kt
@@ -1380,8 +1380,8 @@ class WeekView @JvmOverloads constructor(
                 candidates.isEmpty() -> null
                 // Two events hit. This is most likely because an all-day event was clicked, but a
                 // single event is rendered underneath it. We return the all-day event.
-                candidates.size == 2 -> candidates.first { it.event.isAllDay }
-                else -> candidates.first()
+                candidates.size == 2 -> candidates.first { it.event.isAllDay }.takeUnless { it.isHidden }
+                else -> candidates.first().takeUnless { it.isHidden }
             }
         }
 

--- a/core/src/main/java/com/alamkanak/weekview/WeekView.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekView.kt
@@ -48,7 +48,7 @@ class WeekView @JvmOverloads constructor(
     private val renderers: List<Renderer> = listOf(
         TimeColumnRenderer(viewState),
         CalendarRenderer(viewState, eventChipsCache),
-        HeaderRenderer(viewState, eventChipsCache, onHeaderHeightChanged = this::invalidate)
+        HeaderRenderer(context, viewState, eventChipsCache, onHeaderHeightChanged = this::invalidate)
     )
 
     init {

--- a/core/src/main/java/com/alamkanak/weekview/WeekView.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekView.kt
@@ -185,6 +185,18 @@ class WeekView @JvmOverloads constructor(
             viewState.showFirstDayOfWeekFirst = value
         }
 
+    /**
+     * Returns whether all-day events are arranged vertically. If false, all-day events are shown
+     * in a horizontal arrangement, occupying only a single row.
+     */
+    @PublicApi
+    var arrangeAllDayEventsVertically: Boolean
+        get() = viewState.arrangeAllDayEventsVertically
+        set(value) {
+            viewState.arrangeAllDayEventsVertically = value
+            invalidate()
+        }
+
     /*
      ***********************************************************************************************
      *

--- a/core/src/main/java/com/alamkanak/weekview/WeekViewGestureHandler.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekViewGestureHandler.kt
@@ -176,11 +176,9 @@ internal class WeekViewGestureHandler(
         )
     }
 
-    override fun onSingleTapConfirmed(
-        e: MotionEvent
-    ): Boolean {
+    override fun onSingleTapUp(e: MotionEvent): Boolean {
         touchHandler.handleClick(e.x, e.y)
-        return super.onSingleTapConfirmed(e)
+        return super.onSingleTapUp(e)
     }
 
     override fun onLongPress(e: MotionEvent) {

--- a/core/src/main/java/com/alamkanak/weekview/WeekViewTouchHandler.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekViewTouchHandler.kt
@@ -12,6 +12,14 @@ internal class WeekViewTouchHandler(
 
     fun handleClick(x: Float, y: Float) {
         val inCalendarArea = x > viewState.timeColumnWidth
+        val inAllDayEventsToggleArea = viewState.toggleAllDayEventsAreaBounds.contains(x, y)
+
+        if (inAllDayEventsToggleArea) {
+            viewState.allDayEventsExpanded = !viewState.allDayEventsExpanded
+            adapter?.updateObserver()
+            return
+        }
+
         if (!inCalendarArea) {
             return
         }

--- a/core/src/main/java/com/alamkanak/weekview/WeekViewTouchHandler.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekViewTouchHandler.kt
@@ -14,7 +14,7 @@ internal class WeekViewTouchHandler(
         val inCalendarArea = x > viewState.timeColumnWidth
         val inAllDayEventsToggleArea = viewState.toggleAllDayEventsAreaBounds.contains(x, y)
 
-        if (inAllDayEventsToggleArea) {
+        if (inAllDayEventsToggleArea && viewState.showAllDayEventsToggleArrow) {
             viewState.allDayEventsExpanded = !viewState.allDayEventsExpanded
             adapter?.updateObserver()
             return

--- a/core/src/main/res/drawable/ic_arrow_down.xml
+++ b/core/src/main/res/drawable/ic_arrow_down.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7.41,8.59L12,13.17l4.59,-4.58L18,10l-6,6 -6,-6 1.41,-1.41z" />
+</vector>

--- a/core/src/main/res/drawable/ic_arrow_up.xml
+++ b/core/src/main/res/drawable/ic_arrow_up.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="?attr/colorControlNormal" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7.41,15.41L12,10.83l4.59,4.58L18,14l-6,-6 -6,6z"/>
+</vector>

--- a/core/src/main/res/values/attrs.xml
+++ b/core/src/main/res/values/attrs.xml
@@ -8,6 +8,7 @@
         <attr name="restoreNumberOfVisibleDays" format="boolean" />
         <attr name="showFirstDayOfWeekFirst" format="boolean" />
         <attr name="showCurrentTimeFirst" format="boolean" />
+        <attr name="arrangeAllDayEventsVertically" format="boolean" />
 
         <!-- Header bottom line -->
         <attr name="showHeaderBottomLine" format="boolean" />

--- a/sample/src/main/java/com/alamkanak/weekview/sample/MainActivity.kt
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/MainActivity.kt
@@ -33,7 +33,7 @@ class MainActivity : AppCompatActivity() {
             Sample(R.string.title_activity_basic, "Asynchronous events fetching\nThreeTenABP extension", BasicActivity::class.java),
             Sample(R.string.title_activity_static, "Static week without horizontal scrolling", StaticActivity::class.java),
             Sample(R.string.title_activity_limited, "Shows only the current month\nLimits days from 8AM to 8PM", LimitedActivity::class.java),
-            Sample(R.string.title_activity_custom_font, "Custom font in WeekView", CustomFontActivity::class.java),
+            Sample(R.string.title_activity_custom_font, "Custom font in WeekView\nAll-day events arranged horizontally", CustomFontActivity::class.java),
             Sample(R.string.title_activity_asynchronous, "Asynchronous events fetching from an API", AsyncActivity::class.java),
             Sample(R.string.title_activity_with_fragment, "Displays WeekView within a Fragment", WithFragmentActivity::class.java),
             Sample(R.string.title_activity_legacy, "Implemented in Java", LegacyActivity::class.java)

--- a/sample/src/main/java/com/alamkanak/weekview/sample/data/EventsDatabase.kt
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/data/EventsDatabase.kt
@@ -176,7 +176,7 @@ class EventsDatabase(context: Context) {
 
         // All-day event
         events += newEvent(
-            id = idOffset + 123456789,
+            id = idOffset + 12,
             year = year,
             month = month,
             dayOfMonth = 28,
@@ -189,7 +189,7 @@ class EventsDatabase(context: Context) {
 
         // All-day event until 00:00 next day
         events += newEvent(
-            id = idOffset + 12,
+            id = idOffset + 13,
             year = year,
             month = month,
             dayOfMonth = 14,

--- a/sample/src/main/java/com/alamkanak/weekview/sample/data/EventsDatabase.kt
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/data/EventsDatabase.kt
@@ -174,6 +174,19 @@ class EventsDatabase(context: Context) {
             color = color2
         )
 
+        // All-day event
+        events += newEvent(
+            id = idOffset + 123456789,
+            year = year,
+            month = month,
+            dayOfMonth = 28,
+            hour = 0,
+            minute = 0,
+            duration = 24 * 60,
+            isAllDay = true,
+            color = color2
+        )
+
         // All-day event until 00:00 next day
         events += newEvent(
             id = idOffset + 12,

--- a/sample/src/main/res/layout/activity_basic.xml
+++ b/sample/src/main/res/layout/activity_basic.xml
@@ -21,6 +21,7 @@
             app:allDayEventTextSize="13sp"
             app:columnGap="6dp"
             app:eventCornerRadius="4dp"
+            app:eventMarginVertical="2dp"
             app:eventPaddingHorizontal="4dp"
             app:eventPaddingVertical="5dp"
             app:eventTextSize="13sp"

--- a/sample/src/main/res/layout/activity_custom_font.xml
+++ b/sample/src/main/res/layout/activity_custom_font.xml
@@ -14,6 +14,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:adaptiveEventTextSize="true"
+        app:arrangeAllDayEventsVertically="false"
         app:columnGap="1dp"
         app:eventCornerRadius="4dp"
         app:eventTextColor="@color/white"


### PR DESCRIPTION
This pull request adds the `arrangeAllDayEventsVertically` attribute (which defaults to `true`). If enabled, all-day events are arranged in a stack and can be collapsed and expanded, if more than two events are displayed. Otherwise, all-day events continue to be arranged in a row.

| **Collapsed** | **Expanded** |
| ------------- | ------------- |
| ![Screenshot_1601501308](https://user-images.githubusercontent.com/11819826/94741679-cae49600-0374-11eb-8f50-e1a85ae07fba.png) | ![Screenshot_1601501310](https://user-images.githubusercontent.com/11819826/94741694-d1730d80-0374-11eb-85c6-47505fec511d.png) |