### PR TITLE
Improve handling of events with different time zones

### DIFF
--- a/core/src/main/java/com/alamkanak/weekview/CalendarExtensions.kt
+++ b/core/src/main/java/com/alamkanak/weekview/CalendarExtensions.kt
@@ -3,6 +3,7 @@ package com.alamkanak.weekview
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
+import java.util.TimeZone
 import kotlin.math.roundToInt
 
 internal const val DAY_IN_MILLIS = 1000L * 60L * 60L * 24L
@@ -261,6 +262,13 @@ internal fun Calendar.withMinutes(minute: Int): Calendar {
     return copy().apply { set(Calendar.MINUTE, minute) }
 }
 
+internal fun Calendar.convertedToDefaultTimeZone(): Calendar {
+    val offset = TimeZone.getDefault().rawOffset - timeZone.rawOffset
+    return copy().apply {
+        timeZone = TimeZone.getDefault()
+    } + Millis(offset)
+}
+
 internal fun Calendar.copy(): Calendar = clone() as Calendar
 
 /**
@@ -289,9 +297,7 @@ internal fun defaultDateFormatter(
 
 internal fun defaultTimeFormatter(): SimpleDateFormat = SimpleDateFormat("hh a", Locale.getDefault())
 
-fun Calendar.format(
-    format: Int = java.text.DateFormat.MEDIUM
-): String {
-    val sdf = SimpleDateFormat.getDateInstance(format)
+internal fun Calendar.format(): String {
+    val sdf = SimpleDateFormat.getDateTimeInstance()
     return sdf.format(time)
 }

--- a/core/src/main/java/com/alamkanak/weekview/CalendarExtensions.kt
+++ b/core/src/main/java/com/alamkanak/weekview/CalendarExtensions.kt
@@ -262,11 +262,11 @@ internal fun Calendar.withMinutes(minute: Int): Calendar {
     return copy().apply { set(Calendar.MINUTE, minute) }
 }
 
-internal fun Calendar.convertedToDefaultTimeZone(): Calendar {
-    val offset = TimeZone.getDefault().rawOffset - timeZone.rawOffset
-    return copy().apply {
-        timeZone = TimeZone.getDefault()
-    } + Millis(offset)
+internal fun Calendar.withLocalTimeZone(): Calendar {
+    val localTimeZone = TimeZone.getDefault()
+    val localCalendar = Calendar.getInstance(localTimeZone)
+    localCalendar.timeInMillis = timeInMillis
+    return localCalendar
 }
 
 internal fun Calendar.copy(): Calendar = clone() as Calendar

--- a/core/src/main/java/com/alamkanak/weekview/ResolvedWeekViewEvent.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ResolvedWeekViewEvent.kt
@@ -11,11 +11,14 @@ internal fun <T> WeekViewDisplayable<T>.toResolvedWeekViewEvent(
 internal fun <T> WeekViewEvent<T>.resolve(
     context: Context
 ): ResolvedWeekViewEvent<T> {
+    val adjustedStartTime = startTime.convertedToDefaultTimeZone()
+    val adjustedEndTime = endTime.convertedToDefaultTimeZone()
+
     return ResolvedWeekViewEvent(
         id = id,
         title = titleResource.resolve(context, semibold = true),
-        startTime = startTime,
-        endTime = endTime,
+        startTime = adjustedStartTime,
+        endTime = adjustedEndTime,
         location = locationResource?.resolve(context, semibold = false),
         isAllDay = isAllDay,
         style = style.resolve(context),
@@ -55,9 +58,11 @@ internal data class ResolvedWeekViewEvent<T>(
 
     internal val isNotAllDay: Boolean = isAllDay.not()
 
-    internal val durationInMinutes: Int = ((endTime.timeInMillis - startTime.timeInMillis).toFloat() / 60_000).roundToInt()
+    internal val durationInMinutes: Int
+        get() = ((endTime.timeInMillis - startTime.timeInMillis).toFloat() / 60_000).roundToInt()
 
-    internal val isMultiDay: Boolean = startTime.isSameDate(endTime).not()
+    internal val isMultiDay: Boolean
+        get() = startTime.isSameDate(endTime).not()
 
     internal fun isWithin(
         minHour: Int,

--- a/core/src/main/java/com/alamkanak/weekview/ResolvedWeekViewEvent.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ResolvedWeekViewEvent.kt
@@ -10,21 +10,16 @@ internal fun <T> WeekViewDisplayable<T>.toResolvedWeekViewEvent(
 
 internal fun <T> WeekViewEvent<T>.resolve(
     context: Context
-): ResolvedWeekViewEvent<T> {
-    val adjustedStartTime = startTime.convertedToDefaultTimeZone()
-    val adjustedEndTime = endTime.convertedToDefaultTimeZone()
-
-    return ResolvedWeekViewEvent(
-        id = id,
-        title = titleResource.resolve(context, semibold = true),
-        startTime = adjustedStartTime,
-        endTime = adjustedEndTime,
-        location = locationResource?.resolve(context, semibold = false),
-        isAllDay = isAllDay,
-        style = style.resolve(context),
-        data = data
-    )
-}
+) = ResolvedWeekViewEvent(
+    id = id,
+    title = titleResource.resolve(context, semibold = true),
+    startTime = startTime.withLocalTimeZone(),
+    endTime = endTime.withLocalTimeZone(),
+    location = locationResource?.resolve(context, semibold = false),
+    isAllDay = isAllDay,
+    style = style.resolve(context),
+    data = data
+)
 
 internal fun WeekViewEvent.Style.resolve(
     context: Context

--- a/sample/src/main/java/com/alamkanak/weekview/sample/BasicActivity.kt
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/BasicActivity.kt
@@ -10,14 +10,11 @@ import com.alamkanak.weekview.sample.util.setupWithWeekView
 import com.alamkanak.weekview.sample.util.showToast
 import com.alamkanak.weekview.threetenabp.WeekViewPagingAdapterThreeTenAbp
 import com.alamkanak.weekview.threetenabp.setDateFormatter
-import java.util.Calendar
 import java.util.Locale
 import kotlinx.android.synthetic.main.activity_basic.weekView
 import kotlinx.android.synthetic.main.view_toolbar.toolbar
-import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
-import org.threeten.bp.ZoneId
 import org.threeten.bp.format.DateTimeFormatter
 import org.threeten.bp.format.FormatStyle.MEDIUM
 import org.threeten.bp.format.FormatStyle.SHORT
@@ -88,8 +85,4 @@ private class BasicActivityWeekViewAdapter(
     override fun onLoadMore(startDate: LocalDate, endDate: LocalDate) {
         loadMoreHandler(startDate, endDate)
     }
-}
-
-private fun Calendar.toLocalDate(): LocalDate {
-    return Instant.ofEpochMilli(timeInMillis).atZone(ZoneId.systemDefault()).toLocalDate()
 }

--- a/sample/src/main/java/com/alamkanak/weekview/sample/data/EventsDatabase.kt
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/data/EventsDatabase.kt
@@ -128,18 +128,6 @@ class EventsDatabase(context: Context) {
         )
 
         events += newEvent(
-            id = idOffset + 8,
-            year = year,
-            month = month,
-            dayOfMonth = 1,
-            hour = 0,
-            minute = 0,
-            duration = 3 * 60,
-            color = color1,
-            timeZone = TimeZone.getTimeZone("Europe/London")
-        )
-
-        events += newEvent(
             id = idOffset + 9,
             year = year,
             month = month,
@@ -202,6 +190,45 @@ class EventsDatabase(context: Context) {
             color = color4
         )
 
+        events += newEvent(
+            id = idOffset + 13,
+            year = year,
+            month = month,
+            dayOfMonth = 1,
+            hour = 0,
+            minute = 0,
+            duration = 3 * 60,
+            color = color1,
+            title = "Event in London",
+            timeZone = TimeZone.getTimeZone("Europe/London")
+        )
+
+        events += newEvent(
+            id = idOffset + 14,
+            year = year,
+            month = month,
+            dayOfMonth = 1,
+            hour = 0,
+            minute = 0,
+            duration = 3 * 60,
+            color = color2,
+            title = "Event in Toronto",
+            timeZone = TimeZone.getTimeZone("America/Toronto")
+        )
+
+        events += newEvent(
+            id = idOffset + 15,
+            year = year,
+            month = month,
+            dayOfMonth = 1,
+            hour = 0,
+            minute = 0,
+            duration = 3 * 60,
+            color = color3,
+            title = "Event in LA",
+            timeZone = TimeZone.getTimeZone("America/Los_Angeles")
+        )
+
         return events
     }
 
@@ -215,11 +242,11 @@ class EventsDatabase(context: Context) {
         duration: Int,
         color: Int,
         timeZone: TimeZone = TimeZone.getDefault(),
+        title: String = "Event $id",
         isAllDay: Boolean = false,
         isCanceled: Boolean = false
     ): Event {
-        val startTime = Calendar.getInstance().apply {
-            this.timeZone = timeZone
+        val startTime = Calendar.getInstance(timeZone).apply {
             set(Calendar.YEAR, year)
             set(Calendar.MONTH, month)
             set(Calendar.DAY_OF_MONTH, dayOfMonth)
@@ -233,7 +260,7 @@ class EventsDatabase(context: Context) {
 
         return Event(
             id = id,
-            title = "Event $id",
+            title = title,
             startTime = startTime,
             endTime = endTime,
             location = "Location 123",

--- a/sample/src/main/java/com/alamkanak/weekview/sample/data/EventsDatabase.kt
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/data/EventsDatabase.kt
@@ -7,6 +7,7 @@ import com.alamkanak.weekview.sample.R
 import com.alamkanak.weekview.sample.data.model.Event
 import com.alamkanak.weekview.sample.util.toCalendar
 import java.util.Calendar
+import java.util.TimeZone
 import org.threeten.bp.LocalDate
 
 class EventsDatabase(context: Context) {
@@ -131,10 +132,11 @@ class EventsDatabase(context: Context) {
             year = year,
             month = month,
             dayOfMonth = 1,
-            hour = 9,
+            hour = 0,
             minute = 0,
             duration = 3 * 60,
-            color = color1
+            color = color1,
+            timeZone = TimeZone.getTimeZone("Europe/London")
         )
 
         events += newEvent(
@@ -212,10 +214,12 @@ class EventsDatabase(context: Context) {
         minute: Int,
         duration: Int,
         color: Int,
+        timeZone: TimeZone = TimeZone.getDefault(),
         isAllDay: Boolean = false,
         isCanceled: Boolean = false
     ): Event {
         val startTime = Calendar.getInstance().apply {
+            this.timeZone = timeZone
             set(Calendar.YEAR, year)
             set(Calendar.MONTH, month)
             set(Calendar.DAY_OF_MONTH, dayOfMonth)


### PR DESCRIPTION
Resolves: https://github.com/thellmund/Android-Week-View/issues/189

This pull request improves how `WeekView` handles events with time zones different from the device’s time zone. Previously, it could happen that these events weren’t rendered in `WeekView` at all.