### PR TITLE
Streamline API for scrolling to dates and times

### DIFF
--- a/core/src/main/java/com/alamkanak/weekview/ViewState.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ViewState.kt
@@ -294,10 +294,10 @@ internal class ViewState {
             currentOrigin.x += dayWidth * difference * factor
         }
 
-        currentOrigin.x = currentOrigin.x.limit(minValue = minX, maxValue = maxX)
+        currentOrigin.x = currentOrigin.x.coerceIn(minimumValue = minX, maximumValue = maxX)
     }
 
-    private fun scrollToCurrentTime() {
+    private fun renderCurrentTime() {
         val desired = now()
         if (desired.hour > minHour) {
             // Add some padding above the current time (and thus: the now line)
@@ -306,7 +306,7 @@ internal class ViewState {
             desired -= Minutes(desired.minute)
         }
 
-        desired.hour = min(max(desired.hour, minHour), maxHour)
+        desired.hour = desired.hour.coerceIn(minimumValue = minHour, maximumValue = maxHour)
         desired.minute = 0
 
         val fraction = desired.minute / 60f
@@ -317,22 +317,24 @@ internal class ViewState {
     }
 
     /**
-     * Returns the provided date, if it is within [minDate] and [maxDate]. Otherwise, it returns
-     * [minDate] or [maxDate].
+     * Returns a valid start date based on the provided [candidate]. If it falls outside the range
+     * of [minDate] and [maxDate], it will be adjusted accordingly.
+     *
+     * @return A [Calendar] of the valid start date
      */
-    fun getDateWithinDateRange(date: Calendar): Calendar {
-        val minDate = minDate ?: date
-        val maxDate = maxDate ?: date
+    fun getStartDateInAllowedRange(candidate: Calendar): Calendar {
+        val minDate = minDate ?: candidate
+        val maxDate = maxDate ?: candidate
 
-        return if (date.isBefore(minDate)) {
+        return if (candidate.isBefore(minDate)) {
             minDate
-        } else if (date.isAfter(maxDate)) {
+        } else if (candidate.isAfter(maxDate)) {
             maxDate - Days(numberOfVisibleDays - 1)
         } else if (numberOfVisibleDays >= 7 && showFirstDayOfWeekFirst) {
-            val diff = date.computeDifferenceWithFirstDayOfWeek()
-            date - Days(diff)
+            val diff = candidate.computeDifferenceWithFirstDayOfWeek()
+            candidate - Days(diff)
         } else {
-            date
+            candidate
         }
     }
 
@@ -362,9 +364,9 @@ internal class ViewState {
             val newMinHourHeight = (viewHeight - headerHeight) / hoursPerDay
             val effectiveMinHourHeight = max(minHourHeight, newMinHourHeight)
 
-            newHourHeight = newHourHeight.limit(
-                minValue = effectiveMinHourHeight,
-                maxValue = maxHourHeight
+            newHourHeight = newHourHeight.coerceIn(
+                minimumValue = effectiveMinHourHeight,
+                maximumValue = maxHourHeight
             )
 
             currentOrigin.y = currentOrigin.y / hourHeight * newHourHeight
@@ -458,7 +460,7 @@ internal class ViewState {
         }
 
         if (showCurrentTimeFirst) {
-            scrollToCurrentTime()
+            renderCurrentTime()
         }
 
         isFirstDraw = false

--- a/core/src/main/java/com/alamkanak/weekview/WeekView.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekView.kt
@@ -14,7 +14,6 @@ import android.view.accessibility.AccessibilityManager
 import androidx.annotation.RequiresApi
 import androidx.core.view.ViewCompat
 import java.util.Calendar
-import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 
@@ -1143,45 +1142,90 @@ class WeekView @JvmOverloads constructor(
      */
     @PublicApi
     val lastVisibleDate: Calendar
-        get() = viewState.firstVisibleDate.copy() + Days(viewState.numberOfVisibleDays - 1)
+        get() = viewState.firstVisibleDate + Days(viewState.numberOfVisibleDays - 1)
 
     /**
-     * Shows the current date.
+     * Scrolls to the specified date. Any provided [Calendar] that falls outside the range of
+     * [minDate] and [maxDate] will be adjusted to fit into this range.
+     *
+     * @param date A [Calendar] representing the date to scroll to.
      */
+    @PublicApi
+    fun scrollToDate(date: Calendar) {
+        scrollToDateWithCompletion(date.withLocalTimeZone())
+    }
+
+    /**
+     * Scrolls to the specified date time. Any provided [Calendar] that falls outside the range of
+     * [minDate] and [maxDate], or [minHour] and [maxHour], will be adjusted to fit into these
+     * ranges.
+     *
+     * @param dateTime A [Calendar] representing the date time to scroll to.
+     */
+    @PublicApi
+    fun scrollToDateTime(dateTime: Calendar) {
+        val localeDate = dateTime.withLocalTimeZone()
+        scrollToDateWithCompletion(localeDate) {
+            goToHour(localeDate.hour)
+        }
+    }
+
+    /**
+     * Scrolls to the specified time. Any provided time that falls outside the range of [minHour]
+     * and [maxHour] will be adjusted to fit into these ranges.
+     *
+     * @param hour The hour to scroll to.
+     * @param minute The minute to scroll to.
+     */
+    @PublicApi
+    fun scrollToTime(hour: Int, minute: Int) {
+        val date = viewState.firstVisibleDate.withTime(hour, minute)
+        scrollToDateTime(date)
+    }
+
+    /**
+     * Scrolls to the current date.
+     */
+    @Deprecated(
+        message = "This method will be removed in a future release. Use scrollToDate() instead.",
+        replaceWith = ReplaceWith(expression = "scrollToDate")
+    )
     @PublicApi
     fun goToToday() {
         goToDate(today())
     }
 
     /**
-     * Shows the current date and time.
+     * Scrolls to the current date and time.
      */
+    @Deprecated(
+        message = "This method will be removed in a future release. Use scrollToDateTime() instead.",
+        replaceWith = ReplaceWith(expression = "scrollToDateTime")
+    )
     @PublicApi
     fun goToCurrentTime() {
         val now = now()
-        goToDateWithCompletion(now) {
-            goToHour(now.hour)
-        }
+        scrollToDateWithCompletion(now, onComplete = { goToHour(now.hour) })
     }
 
     /**
-     * Shows a specific date. If it is before [minDate] or after [maxDate], these will be shown
-     * instead.
+     * Scrolls to a specific date. If the date is before [minDate] or after [maxDate], [WeekView]
+     * will scroll to them instead.
      *
      * @param date The date to show.
      */
+    @Deprecated(
+        message = "This method will be removed in a future release. Use scrollToDate() instead.",
+        replaceWith = ReplaceWith(expression = "scrollToDate")
+    )
     @PublicApi
     fun goToDate(date: Calendar) {
-        goToDateWithCompletion(date, onComplete = {})
+        scrollToDateWithCompletion(date)
     }
 
-    private fun goToDateWithCompletion(date: Calendar, onComplete: () -> Unit) {
-        val adjustedDate = viewState.getDateWithinDateRange(date)
-        if (adjustedDate.toEpochDays() == viewState.firstVisibleDate.toEpochDays()) {
-            return
-        }
-
+    private fun scrollToDateWithCompletion(date: Calendar, onComplete: () -> Unit = {}) {
         gestureHandler.forceScrollFinished()
+        val adjustedDate = viewState.getStartDateInAllowedRange(date)
 
         val isWaitingToBeLaidOut = ViewCompat.isLaidOut(this).not()
         if (isWaitingToBeLaidOut) {
@@ -1192,9 +1236,9 @@ class WeekView @JvmOverloads constructor(
         }
 
         val destinationOffset = viewState.getXOriginForDate(date)
-        val adjustedDestinationOffset = destinationOffset.limit(
-            minValue = viewState.minX,
-            maxValue = viewState.maxX
+        val adjustedDestinationOffset = destinationOffset.coerceIn(
+            minimumValue = viewState.minX,
+            maximumValue = viewState.maxX
         )
 
         scroller.animate(
@@ -1216,28 +1260,43 @@ class WeekView @JvmOverloads constructor(
     }
 
     /**
-     * Scrolls to a specific hour. If it is before [minHour] or after [maxHour], these will be shown
-     * instead.
+     * Scrolls to a specific hour. If the hour is before [minHour] or after [maxHour], [WeekView]
+     * will scroll to them instead.
      *
      * @param hour The hour to scroll to, in 24-hour format. Supported values are 0-24.
      */
+    @Deprecated(
+        message = "This method will be removed in a future release. Use scrollToTime() instead.",
+        replaceWith = ReplaceWith(expression = "scrollToTime")
+    )
     @PublicApi
     fun goToHour(hour: Int) {
         val isWaitingToBeLaidOut = ViewCompat.isLaidOut(this).not()
         if (isWaitingToBeLaidOut) {
+            // If the view's dimensions have just changed or if it hasn't been laid out yet, we
+            // postpone the action until onDraw() is called the next time.
             viewState.scrollToHour = hour
             return
         }
 
-        val sanitizedHour = min(max(hour, viewState.minHour), viewState.maxHour)
-        val hourHeight = viewState.hourHeight
-        val desiredOffset = hourHeight * (sanitizedHour - viewState.minHour)
+        val sanitizedHour = hour.coerceIn(minimumValue = minHour, maximumValue = maxHour)
+        val desired = now().withTime(hour = sanitizedHour, minutes = 0)
+
+        if (desired.hour > minHour) {
+            // Add some padding above the current time (and thus: the now line)
+            desired -= Hours(1)
+        } else {
+            desired -= Minutes(desired.minute)
+        }
+
+        val fraction = desired.minute / 60f
+        val verticalOffset = hourHeight * (desired.hour + fraction)
 
         // We make sure that WeekView doesn't "over-scroll" by limiting the offset to the total day
         // height minus the height of WeekView, which would result in scrolling all the way to the
         // bottom.
         val maxOffset = viewState.dayHeight - height
-        val finalOffset = min(maxOffset, desiredOffset) * (-1)
+        val finalOffset = min(maxOffset, verticalOffset) * (-1)
 
         scroller.animate(
             fromValue = viewState.currentOrigin.y,

--- a/core/src/main/java/com/alamkanak/weekview/WeekViewGestureHandler.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekViewGestureHandler.kt
@@ -12,8 +12,6 @@ import com.alamkanak.weekview.Direction.Right
 import com.alamkanak.weekview.Direction.Vertical
 import java.util.Calendar
 import kotlin.math.abs
-import kotlin.math.max
-import kotlin.math.min
 import kotlin.math.roundToInt
 
 private enum class Direction {
@@ -89,9 +87,9 @@ internal class WeekViewGestureHandler(
         when (currentScrollDirection) {
             Left, Right -> {
                 viewState.currentOrigin.x -= distanceX
-                viewState.currentOrigin.x = viewState.currentOrigin.x.limit(
-                    minValue = viewState.minX,
-                    maxValue = viewState.maxX
+                viewState.currentOrigin.x = viewState.currentOrigin.x.coerceIn(
+                    minimumValue = viewState.minX,
+                    maximumValue = viewState.maxX
                 )
                 onInvalidation()
             }
@@ -150,9 +148,9 @@ internal class WeekViewGestureHandler(
         }
 
         val destinationOffset = viewState.getXOriginForDate(destinationDate)
-        val adjustedDestinationOffset = destinationOffset.limit(
-            minValue = viewState.minX,
-            maxValue = viewState.maxX
+        val adjustedDestinationOffset = destinationOffset.coerceIn(
+            minimumValue = viewState.minX,
+            maximumValue = viewState.maxX
         )
 
         scroller.animate(
@@ -176,7 +174,10 @@ internal class WeekViewGestureHandler(
 
         val currentOffset = viewState.currentOrigin.y
         val destinationOffset = currentOffset + (originalVelocityY * 0.18).roundToInt()
-        val adjustedDestinationOffset = destinationOffset.limit(minValue = minY, maxValue = maxY)
+        val adjustedDestinationOffset = destinationOffset.coerceIn(
+            minimumValue = minY,
+            maximumValue = maxY
+        )
 
         scroller.animate(
             fromValue = viewState.currentOrigin.y,
@@ -248,5 +249,3 @@ internal class WeekViewGestureHandler(
     private val Context.scaledTouchSlop: Int
         get() = ViewConfiguration.get(this).scaledTouchSlop
 }
-
-internal fun Float.limit(minValue: Float, maxValue: Float): Float = min(max(this, minValue), maxValue)

--- a/jodatime/src/main/java/com/alamkanak/weekview/jodatime/WeekViewExtensions.kt
+++ b/jodatime/src/main/java/com/alamkanak/weekview/jodatime/WeekViewExtensions.kt
@@ -4,6 +4,7 @@ import com.alamkanak.weekview.WeekView
 import com.alamkanak.weekview.WeekViewEvent
 import org.joda.time.LocalDate
 import org.joda.time.LocalDateTime
+import org.joda.time.LocalTime
 
 fun <T : Any> WeekViewEvent.Builder<T>.setStartTime(startTime: LocalDateTime): WeekViewEvent.Builder<T> {
     return setStartTime(startTime.toCalendar())
@@ -46,13 +47,48 @@ val WeekView.lastVisibleDateAsLocalDate: LocalDate
     get() = lastVisibleDate.toLocalDate()
 
 /**
- * Shows a specific date. If it is before [WeekView.minDate] or after [WeekView.maxDate], these will be shown
- * instead.
+ * Scrolls to the specified date. If it is before [WeekView.minDate] or after [WeekView.maxDate],
+ * these will be shown instead.
  *
  * @param date The [LocalDate] to show.
  */
+@Deprecated(
+    message = "This method has been renamed to scrollTo().",
+    replaceWith = ReplaceWith(expression = "scrollTo")
+)
 fun WeekView.goToDate(date: LocalDate) {
-    goToDate(date.toCalendar())
+    scrollToDate(date)
+}
+
+/**
+ * Scrolls to the specified date. Any provided [LocalDate] that falls outside the range of
+ * [WeekView.minDate] and [WeekView.maxDate] will be adjusted to fit into this range.
+ *
+ * @param date The [LocalDate] to scroll to.
+ */
+fun WeekView.scrollToDate(date: LocalDate) {
+    scrollToDate(date.toCalendar())
+}
+
+/**
+ * Scrolls to the specified date time. Any provided [LocalDateTime] that falls outside the range of
+ * [WeekView.minDate] and [WeekView.maxDate], or [WeekView.minHour] and [WeekView.maxHour], will be
+ * adjusted to fit into these ranges.
+ *
+ * @param dateTime The [LocalDateTime] to scroll to.
+ */
+fun WeekView.scrollToDateTime(dateTime: LocalDateTime) {
+    scrollToDateTime(dateTime.toCalendar())
+}
+
+/**
+ * Scrolls to the specified time. Any provided [LocalTime] that falls outside the range of
+ * [WeekView.minHour] and [WeekView.maxHour] will be adjusted to fit into these ranges.
+ *
+ * @param time The [LocalTime] to scroll to.
+ */
+fun WeekView.scrollToTime(time: LocalTime) {
+    scrollToTime(time.hourOfDay, time.secondOfMinute)
 }
 
 fun WeekView.setDateFormatter(formatter: (LocalDate) -> String) {

--- a/jsr310/src/main/java/com/alamkanak/weekview/jsr310/WeekViewExtensions.kt
+++ b/jsr310/src/main/java/com/alamkanak/weekview/jsr310/WeekViewExtensions.kt
@@ -4,6 +4,7 @@ import com.alamkanak.weekview.WeekView
 import com.alamkanak.weekview.WeekViewEvent
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 fun <T : Any> WeekViewEvent.Builder<T>.setStartTime(startTime: LocalDateTime): WeekViewEvent.Builder<T> {
     return setStartTime(startTime.toCalendar())
@@ -46,13 +47,48 @@ val WeekView.lastVisibleDateAsLocalDate: LocalDate
     get() = lastVisibleDate.toLocalDate()
 
 /**
- * Shows a specific date. If it is before [WeekView.minDate] or after [WeekView.maxDate], these will be shown
- * instead.
+ * Scrolls to the specified date. If it is before [WeekView.minDate] or after [WeekView.maxDate],
+ * these will be shown instead.
  *
  * @param date The [LocalDate] to show.
  */
+@Deprecated(
+    message = "This method has been renamed to scrollTo().",
+    replaceWith = ReplaceWith(expression = "scrollTo")
+)
 fun WeekView.goToDate(date: LocalDate) {
-    goToDate(date.toCalendar())
+    scrollToDate(date)
+}
+
+/**
+ * Scrolls to the specified date. Any provided [LocalDate] that falls outside the range of
+ * [WeekView.minDate] and [WeekView.maxDate] will be adjusted to fit into this range.
+ *
+ * @param date The [LocalDate] to scroll to.
+ */
+fun WeekView.scrollToDate(date: LocalDate) {
+    scrollToDate(date.toCalendar())
+}
+
+/**
+ * Scrolls to the specified date time. Any provided [LocalDateTime] that falls outside the range of
+ * [WeekView.minDate] and [WeekView.maxDate], or [WeekView.minHour] and [WeekView.maxHour], will be
+ * adjusted to fit into these ranges.
+ *
+ * @param dateTime The [LocalDateTime] to scroll to.
+ */
+fun WeekView.scrollToDateTime(dateTime: LocalDateTime) {
+    scrollToDateTime(dateTime.toCalendar())
+}
+
+/**
+ * Scrolls to the specified time. Any provided [LocalTime] that falls outside the range of
+ * [WeekView.minHour] and [WeekView.maxHour] will be adjusted to fit into these ranges.
+ *
+ * @param time The [LocalTime] to scroll to.
+ */
+fun WeekView.scrollToTime(time: LocalTime) {
+    scrollToTime(time.hour, time.minute)
 }
 
 fun WeekView.setDateFormatter(formatter: (LocalDate) -> String) {

--- a/sample/src/main/java/com/alamkanak/weekview/sample/util/ToolbarExtensions.kt
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/util/ToolbarExtensions.kt
@@ -6,6 +6,8 @@ import android.view.MenuItem
 import androidx.appcompat.widget.Toolbar
 import com.alamkanak.weekview.WeekView
 import com.alamkanak.weekview.sample.R
+import com.alamkanak.weekview.threetenabp.scrollToDateTime
+import org.threeten.bp.LocalDateTime
 
 private enum class WeekViewType(val value: Int) {
     DayView(1),
@@ -29,7 +31,7 @@ fun Toolbar.setupWithWeekView(weekView: WeekView) {
     setOnMenuItemClickListener { item ->
         when (item.itemId) {
             R.id.action_today -> {
-                weekView.goToToday()
+                weekView.scrollToDateTime(dateTime = LocalDateTime.now())
                 true
             }
             else -> {

--- a/threetenabp/src/main/java/com/alamkanak/weekview/threetenabp/WeekViewExtensions.kt
+++ b/threetenabp/src/main/java/com/alamkanak/weekview/threetenabp/WeekViewExtensions.kt
@@ -4,6 +4,7 @@ import com.alamkanak.weekview.WeekView
 import com.alamkanak.weekview.WeekViewEvent
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
+import org.threeten.bp.LocalTime
 
 fun <T : Any> WeekViewEvent.Builder<T>.setStartTime(startTime: LocalDateTime): WeekViewEvent.Builder<T> {
     return setStartTime(startTime.toCalendar())
@@ -46,13 +47,48 @@ val WeekView.lastVisibleDateAsLocalDate: LocalDate
     get() = lastVisibleDate.toLocalDate()
 
 /**
- * Shows a specific date. If it is before [WeekView.minDate] or after [WeekView.maxDate], these will be shown
- * instead.
+ * Scrolls to the specified date. If it is before [WeekView.minDate] or after [WeekView.maxDate],
+ * these will be shown instead.
  *
  * @param date The [LocalDate] to show.
  */
+@Deprecated(
+    message = "This method has been renamed to scrollToDate(LocalDate).",
+    replaceWith = ReplaceWith(expression = "scrollToDate")
+)
 fun WeekView.goToDate(date: LocalDate) {
-    goToDate(date.toCalendar())
+    scrollToDate(date)
+}
+
+/**
+ * Scrolls to the specified date. Any provided [LocalDate] that falls outside the range of
+ * [WeekView.minDate] and [WeekView.maxDate] will be adjusted to fit into this range.
+ *
+ * @param date The [LocalDate] to scroll to.
+ */
+fun WeekView.scrollToDate(date: LocalDate) {
+    scrollToDate(date.toCalendar())
+}
+
+/**
+ * Scrolls to the specified date time. Any provided [LocalDateTime] that falls outside the range of
+ * [WeekView.minDate] and [WeekView.maxDate], or [WeekView.minHour] and [WeekView.maxHour], will be
+ * adjusted to fit into these ranges.
+ *
+ * @param dateTime The [LocalDateTime] to scroll to.
+ */
+fun WeekView.scrollToDateTime(dateTime: LocalDateTime) {
+    scrollToDateTime(dateTime.toCalendar())
+}
+
+/**
+ * Scrolls to the specified time. Any provided [LocalTime] that falls outside the range of
+ * [WeekView.minHour] and [WeekView.maxHour] will be adjusted to fit into these ranges.
+ *
+ * @param time The [LocalTime] to scroll to.
+ */
+fun WeekView.scrollToTime(time: LocalTime) {
+    scrollToTime(time.hour, time.minute)
 }
 
 fun WeekView.setDateFormatter(formatter: (LocalDate) -> String) {


### PR DESCRIPTION
This pull request streamlines the API for scrolling to specific dates and times. It now consists of three methods that cover all scenarios:
- `scrollToDate(date: Calendar)` scrolls to a specific date, but doesn’t alter the displayed time range.
- `scrollToTime(hour: Int, minute: Int)` scrolls to a specific time, but doesn’t alter the displayed date range.
- `scrollToDateTime(dateTime: Calendar)` scrolls to a specific date and time. The horizontal scrolling is performed first, the vertical scrolling second.

These methods will replace `goToDate(date: Calendar)` and `goToHour(hour: Int)`, which are now deprecated and will be removed in the future.

The API in the date library extension modules is slightly different, as JodaTime, JSR310, and ThreeTenABP offer the more expressive date classes `LocalDate`, `LocalTime` and `LocalDateTime`.
- `scrollToDate(date: LocalDate)` scrolls to a specific date, but doesn’t alter the displayed time range.
- `scrollToTime(time: LocalTime)` scrolls to a specific time, but doesn’t alter the displayed date range.
- `scrollToDateTime(dateTime: LocalDateTime)` scrolls to a specific date and time. The horizontal scrolling is performed first, the vertical scrolling second.

The convenience methods `goToToday()` and `goToCurrentTime()` are now deprecated and will be removed in the future.
