### PR TITLE
Fix bugs around scrolling and behavior of onRangeChanged()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,6 @@
 
 buildscript {
     apply from: 'dependencies.gradle'
-    ext {
-        kotlin_version = '1.4.10'
-    }
     repositories {
         jcenter()
         google()
@@ -13,7 +10,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:9.2.1'

--- a/core/src/main/java/com/alamkanak/weekview/Navigator.kt
+++ b/core/src/main/java/com/alamkanak/weekview/Navigator.kt
@@ -7,10 +7,10 @@ internal class Navigator(
     private val listener: NavigationListener
 ) {
 
-    private val scroller = ValueAnimator()
+    private val animator = ValueAnimator()
 
     val isNotRunning: Boolean
-        get() = !scroller.isRunning
+        get() = !animator.isRunning
 
     fun scrollHorizontallyBy(distance: Float) {
         viewState.currentOrigin.x -= distance
@@ -33,7 +33,7 @@ internal class Navigator(
             maximumValue = viewState.maxX
         )
 
-        scroller.animate(
+        animator.animate(
             fromValue = viewState.currentOrigin.x,
             toValue = adjustedDestinationOffset,
             onUpdate = {
@@ -48,7 +48,7 @@ internal class Navigator(
     }
 
     fun scrollHorizontallyTo(offset: Float) {
-        scroller.animate(
+        animator.animate(
             fromValue = viewState.currentOrigin.x,
             toValue = offset,
             onUpdate = {
@@ -71,7 +71,7 @@ internal class Navigator(
             maximumValue = maxY
         )
 
-        scroller.animate(
+        animator.animate(
             fromValue = viewState.currentOrigin.y,
             toValue = finalOffset,
             onUpdate = {
@@ -82,7 +82,7 @@ internal class Navigator(
     }
 
     fun stop() {
-        scroller.stop()
+        animator.stop()
     }
 
     fun requestInvalidation() {

--- a/core/src/main/java/com/alamkanak/weekview/Navigator.kt
+++ b/core/src/main/java/com/alamkanak/weekview/Navigator.kt
@@ -1,0 +1,98 @@
+package com.alamkanak.weekview
+
+import java.util.Calendar
+
+internal class Navigator(
+    private val viewState: ViewState,
+    private val listener: NavigationListener
+) {
+
+    private val scroller = ValueAnimator()
+
+    val isNotRunning: Boolean
+        get() = !scroller.isRunning
+
+    fun scrollHorizontallyBy(distance: Float) {
+        viewState.currentOrigin.x -= distance
+        viewState.currentOrigin.x = viewState.currentOrigin.x.coerceIn(
+            minimumValue = viewState.minX,
+            maximumValue = viewState.maxX
+        )
+        listener.onHorizontalScrollPositionChanged()
+    }
+
+    fun scrollVerticallyBy(distance: Float) {
+        viewState.currentOrigin.y -= distance
+        listener.onVerticalScrollPositionChanged()
+    }
+
+    fun scrollHorizontallyTo(date: Calendar, onFinished: () -> Unit = {}) {
+        val destinationOffset = viewState.getXOriginForDate(date)
+        val adjustedDestinationOffset = destinationOffset.coerceIn(
+            minimumValue = viewState.minX,
+            maximumValue = viewState.maxX
+        )
+
+        scroller.animate(
+            fromValue = viewState.currentOrigin.x,
+            toValue = adjustedDestinationOffset,
+            onUpdate = {
+                viewState.currentOrigin.x = it
+                listener.onHorizontalScrollPositionChanged()
+            },
+            onEnd = {
+                listener.onHorizontalScrollingFinished()
+                onFinished()
+            }
+        )
+    }
+
+    fun scrollHorizontallyTo(offset: Float) {
+        scroller.animate(
+            fromValue = viewState.currentOrigin.x,
+            toValue = offset,
+            onUpdate = {
+                viewState.currentOrigin.x = it
+                listener.onHorizontalScrollPositionChanged()
+            },
+            onEnd = listener::onHorizontalScrollingFinished
+        )
+    }
+
+    fun scrollVerticallyTo(offset: Float) {
+        val dayHeight = viewState.hourHeight * viewState.hoursPerDay
+        val viewHeight = viewState.viewHeight
+
+        val minY = (dayHeight + viewState.headerHeight - viewHeight) * -1
+        val maxY = 0f
+
+        val finalOffset = offset.coerceIn(
+            minimumValue = minY,
+            maximumValue = maxY
+        )
+
+        scroller.animate(
+            fromValue = viewState.currentOrigin.y,
+            toValue = finalOffset,
+            onUpdate = {
+                viewState.currentOrigin.y = it
+                listener.onVerticalScrollPositionChanged()
+            }
+        )
+    }
+
+    fun stop() {
+        scroller.stop()
+    }
+
+    fun requestInvalidation() {
+        listener.requestInvalidation()
+    }
+
+    internal interface NavigationListener {
+        fun onHorizontalScrollPositionChanged()
+        fun onHorizontalScrollingFinished()
+        fun onVerticalScrollPositionChanged()
+        fun requestInvalidation()
+    }
+}

--- a/core/src/main/java/com/alamkanak/weekview/ScaleGestureDetector.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ScaleGestureDetector.kt
@@ -7,32 +7,31 @@ import android.view.ScaleGestureDetector as AndroidScaleGestureDetector
 internal class ScaleGestureDetector(
     context: Context,
     private val viewState: ViewState,
-    private val valueAnimator: ValueAnimator,
-    private val onInvalidation: () -> Unit
+    private val navigator: Navigator
 ) {
 
     private val listener = object : AndroidScaleGestureDetector.OnScaleGestureListener {
 
         override fun onScaleBegin(
             detector: AndroidScaleGestureDetector
-        ): Boolean = !valueAnimator.isRunning
+        ): Boolean = navigator.isNotRunning
 
         override fun onScale(detector: AndroidScaleGestureDetector): Boolean {
             val hourHeight = viewState.hourHeight
             viewState.newHourHeight = hourHeight * detector.scaleFactor
-            onInvalidation()
+            navigator.requestInvalidation()
             return true
         }
 
         override fun onScaleEnd(detector: AndroidScaleGestureDetector) {
-            onInvalidation()
+            navigator.requestInvalidation()
         }
     }
 
     private val detector = AndroidScaleGestureDetector(context, listener)
 
     fun onTouchEvent(event: MotionEvent) {
-        if (!valueAnimator.isRunning && !viewState.showCompleteDay) {
+        if (navigator.isNotRunning && !viewState.showCompleteDay) {
             detector.onTouchEvent(event)
         }
     }

--- a/core/src/main/java/com/alamkanak/weekview/ViewState.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ViewState.kt
@@ -292,7 +292,7 @@ internal class ViewState {
         return if (isLtr) (date.daysFromToday * dayWidth * -1f) else (date.daysFromToday * dayWidth)
     }
 
-    private fun scrollToFirstDayOfWeek() {
+    private fun scrollToFirstDayOfWeek(navigationListener: Navigator.NavigationListener) {
         // If the week view is being drawn for the first time, consider the first day of the week.
         val today = today()
         val isWeekView = numberOfVisibleDays >= 7
@@ -305,6 +305,7 @@ internal class ViewState {
         }
 
         currentOrigin.x = currentOrigin.x.coerceIn(minimumValue = minX, maximumValue = maxX)
+        navigationListener.onHorizontalScrollingFinished()
     }
 
     private fun renderCurrentTime() {
@@ -449,8 +450,8 @@ internal class ViewState {
         timeColumnWidth = lineLength + timeColumnPadding * 2
     }
 
-    fun update() {
-        updateViewState()
+    fun update(navigationListener: Navigator.NavigationListener) {
+        updateViewState(navigationListener)
         updateScrollState()
         updateDateRange()
     }
@@ -460,13 +461,13 @@ internal class ViewState {
         updateVerticalOrigin()
     }
 
-    private fun updateViewState() {
+    private fun updateViewState(navigationListener: Navigator.NavigationListener) {
         if (!isFirstDraw) {
             return
         }
 
         if (showFirstDayOfWeekFirst) {
-            scrollToFirstDayOfWeek()
+            scrollToFirstDayOfWeek(navigationListener)
         }
 
         if (showCurrentTimeFirst) {

--- a/core/src/main/java/com/alamkanak/weekview/WeekView.kt
+++ b/core/src/main/java/com/alamkanak/weekview/WeekView.kt
@@ -204,11 +204,16 @@ class WeekView @JvmOverloads constructor(
     var numberOfVisibleDays: Int
         get() = viewState.numberOfVisibleDays
         set(value) {
+            val currentFirstVisibleDate = viewState.firstVisibleDate
             viewState.numberOfVisibleDays = value
+
             dateTimeInterpreter.onSetNumberOfDays(value)
             renderers.filterIsInstance(DateFormatterDependent::class.java).forEach {
                 it.onDateFormatterChanged(viewState.dateFormatter)
             }
+
+            val newOrigin = viewState.getXOriginForDate(currentFirstVisibleDate)
+            viewState.currentOrigin.x = newOrigin
             invalidate()
         }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,7 +15,7 @@ ext {
             jodaTime          : '2.10.6',
             jodaTimeAndroid   : '2.10.6',
             jUnit             : '4.13',
-            kotlin            : '1.4.10',
+            kotlin            : '1.4.21',
             mockito           : '3.3.3',
             robolectric       : '4.3.1',
             threeTen          : '1.4.4',

--- a/sample/src/main/java/com/alamkanak/weekview/sample/StaticActivity.kt
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/StaticActivity.kt
@@ -13,7 +13,6 @@ import com.alamkanak.weekview.sample.util.setupWithWeekView
 import com.alamkanak.weekview.sample.util.showToast
 import com.alamkanak.weekview.threetenabp.WeekViewPagingAdapterThreeTenAbp
 import com.alamkanak.weekview.threetenabp.firstVisibleDateAsLocalDate
-import com.alamkanak.weekview.threetenabp.lastVisibleDateAsLocalDate
 import com.alamkanak.weekview.threetenabp.scrollToDate
 import kotlinx.android.synthetic.main.activity_static.dateRangeTextView
 import kotlinx.android.synthetic.main.activity_static.leftNavigationButton
@@ -30,7 +29,7 @@ class StaticActivity : AppCompatActivity() {
 
     private val eventsFetcher: EventsFetcher by lazy { EventsFetcher(this) }
 
-    private val dateFormatter = DateTimeFormatter.ofLocalizedDate(MEDIUM)
+    private val dateFormatter = DateTimeFormatter.ofPattern("MM/dd/yyyy")
 
     private val adapter: StaticActivityWeekViewAdapter by lazy {
         StaticActivityWeekViewAdapter(
@@ -45,11 +44,6 @@ class StaticActivity : AppCompatActivity() {
 
         toolbar.setupWithWeekView(weekView)
         weekView.adapter = adapter
-
-        dateRangeTextView.text = buildDateRangeText(
-            startDate = weekView.firstVisibleDateAsLocalDate,
-            endDate = weekView.lastVisibleDateAsLocalDate
-        )
 
         leftNavigationButton.setOnClickListener {
             val firstDate = weekView.firstVisibleDateAsLocalDate


### PR DESCRIPTION
Resolves: #211

This pull request fixes two issues:
1. When changing `numberOfDays`, WeekView would continue to use an incorrect horizontal offset. Now, that offset is recalculated with the new day width, which means that `firstVisibleDate` will now stay consistent.
2. When scrolling in a multi-day view, `onRangeChanged()` was called for every day that was the first visible date during the scroll. Now, WeekView only calls `onRangeChanged()` once for the date that’s the first visible date once scrolling stopped.