### PR TITLE
Fix event splitting before/after min/maxHour

### DIFF
--- a/core/src/test/java/com/alamkanak/weekview/WeekViewEventSplitterTest.kt
+++ b/core/src/test/java/com/alamkanak/weekview/WeekViewEventSplitterTest.kt
@@ -31,6 +31,31 @@ class WeekViewEventSplitterTest {
     }
 
     @Test
+    fun `event before range is ignored`() {
+        whenever(viewState.minHour).thenReturn(7)
+        whenever(viewState.maxHour).thenReturn(21)
+
+        val event = createResolvedWeekViewEvent(today().withHour(1), today().withHour(2))
+
+        val results = event.split(viewState)
+
+        assertEquals(emptyList<ResolvedWeekViewEntity>(), results)
+    }
+
+    @Test
+    fun `event after range is ignored`() {
+        whenever(viewState.minHour).thenReturn(7)
+        whenever(viewState.maxHour).thenReturn(21)
+
+        val event = createResolvedWeekViewEvent(
+                today().withHour(22), today().plus(Days(1)).withHour(6))
+
+        val results = event.split(viewState)
+
+        assertEquals(emptyList<ResolvedWeekViewEntity>(), results)
+    }
+
+    @Test
     fun `two-day event is split correctly`() {
         val startTime = today().withHour(11)
         val endTime = (startTime + Days(1)).withHour(2)
@@ -62,6 +87,78 @@ class WeekViewEventSplitterTest {
             Event(startTime, startTime.atEndOfDay),
             Event(intermediateDate.atStartOfDay, intermediateDate.atEndOfDay),
             Event(endTime.atStartOfDay, endTime)
+        )
+
+        val expectedTimes = expected.map { it.startTime.timeInMillis to it.endTime.timeInMillis }
+        val resultTimes = results.map { it.startTime.timeInMillis to it.endTime.timeInMillis }
+
+        assertEquals(expectedTimes, resultTimes)
+    }
+
+    @Test
+    fun `event with bounds outside of range is split correctly`() {
+        val minHour = 7
+        val maxHour = 21
+        whenever(viewState.minHour).thenReturn(minHour)
+        whenever(viewState.maxHour).thenReturn(maxHour)
+
+        val startTime = today().withHour(5)
+        val endTime = (startTime + Days(2)).withHour(23)
+
+        val event = createResolvedWeekViewEvent(startTime, endTime)
+        val results = event.split(viewState)
+
+        val tomorrow = today() + Days(1)
+        val expected = listOf(
+                Event(startTime.withHour(minHour), startTime.withTimeAtEndOfPeriod(maxHour)),
+                Event(tomorrow.withHour(minHour), tomorrow.withTimeAtEndOfPeriod(maxHour)),
+                Event(endTime.withHour(minHour), endTime.withTimeAtEndOfPeriod(maxHour))
+        )
+
+        val expectedTimes = expected.map { it.startTime.timeInMillis to it.endTime.timeInMillis }
+        val resultTimes = results.map { it.startTime.timeInMillis to it.endTime.timeInMillis }
+
+        assertEquals(expectedTimes, resultTimes)
+    }
+
+    @Test
+    fun `event ending before range start is split correctly`() {
+        val minHour = 7
+        val maxHour = 21
+        whenever(viewState.minHour).thenReturn(minHour)
+        whenever(viewState.maxHour).thenReturn(maxHour)
+
+        val startTime = today().withHour(8)
+        val endTime = (startTime + Days(1)).withHour(5)
+
+        val event = createResolvedWeekViewEvent(startTime, endTime)
+        val results = event.split(viewState)
+
+        val expected = listOf(
+                Event(startTime, startTime.withTimeAtEndOfPeriod(maxHour))
+        )
+
+        val expectedTimes = expected.map { it.startTime.timeInMillis to it.endTime.timeInMillis }
+        val resultTimes = results.map { it.startTime.timeInMillis to it.endTime.timeInMillis }
+
+        assertEquals(expectedTimes, resultTimes)
+    }
+
+    @Test
+    fun `event starting after range end is split correctly`() {
+        val minHour = 7
+        val maxHour = 21
+        whenever(viewState.minHour).thenReturn(minHour)
+        whenever(viewState.maxHour).thenReturn(maxHour)
+
+        val startTime = today().withHour(22)
+        val endTime = (startTime + Days(1)).withHour(9)
+
+        val event = createResolvedWeekViewEvent(startTime, endTime)
+        val results = event.split(viewState)
+
+        val expected = listOf(
+                Event(endTime.withHour(minHour), endTime)
         )
 
         val expectedTimes = expected.map { it.startTime.timeInMillis to it.endTime.timeInMillis }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
             jodaTimeAndroid   : '2.10.6',
             jUnit             : '4.13',
             kotlin            : '1.4.21',
-            mockito           : '3.3.3',
+            mockito           : '3.6.0',
             robolectric       : '4.3.1',
             threeTen          : '1.4.4',
             threeTenAbp       : '1.2.4',


### PR DESCRIPTION
The previous event splitting code would not behave properly with events
starting before minHour, or ending after maxHour : even though 3+ days
events would have the intermediary dates start/end on minHour and
maxHour, the first and last events would start/end outside of that
range.
Single-day events would only be shortened to be within the range in the
special case where they ended exactly on the start of a day, and minHour
is zero.

Fix event splitting to consistently keep events within the
minHour/maxHour range, and add the associated tests.

Also bump mockito to 3.6.0; 3.3.3 does not support the Java 15 JRE.

This addresses #222