### PR TITLE
Initialize ViewState.dateRange on construction

### DIFF
--- a/core/src/main/java/com/alamkanak/weekview/ViewState.kt
+++ b/core/src/main/java/com/alamkanak/weekview/ViewState.kt
@@ -31,18 +31,19 @@ internal class ViewState {
 
     private var isFirstDraw: Boolean = true
 
-    // Drawing context
-    private var startPixel: Float = 0f
-    val startPixels: MutableList<Float> = mutableListOf()
-    val dateRange: MutableList<Calendar> = mutableListOf()
-    val dateRangeWithStartPixels: MutableList<Pair<Calendar, Float>> = mutableListOf()
-
     // Calendar configuration
     var numberOfVisibleDays: Int = 3
     var restoreNumberOfVisibleDays: Boolean = true
     var showFirstDayOfWeekFirst: Boolean = false
     var showCurrentTimeFirst: Boolean = false
     var arrangeAllDayEventsVertically: Boolean = true
+
+    // Drawing context
+    private var startPixel: Float = 0f
+    val startPixels: MutableList<Float> = mutableListOf()
+    val dateRange: MutableList<Calendar> =
+            createDateRange(firstVisibleDate).validate(this).toMutableList()
+    val dateRangeWithStartPixels: MutableList<Pair<Calendar, Float>> = mutableListOf()
 
     // Time column
     var timeColumnPadding: Int = 0


### PR DESCRIPTION
WeekView.first/lastVisibleDate recently switched to returning the
first/last vaues in ViewState.dateRange. This causes crashes if the
property is read before the view is first drawn.

Initialize ViewState.dateRange when constructing it, to avoid the
crashes.